### PR TITLE
Fix: Demo Reliability for UI + Others

### DIFF
--- a/identity/control-plane/deployments/docker-compose.yml
+++ b/identity/control-plane/deployments/docker-compose.yml
@@ -129,7 +129,7 @@ services:
       context: ../ui
       dockerfile: Dockerfile
     environment:
-      NEXT_PUBLIC_CONTROLPLANE_URL: http://localhost:8080
+      CONTROLPLANE_API_URL: http://controlplane-api:8080
       NEXT_PUBLIC_TENANT_ID: ""
     ports:
       - "3000:3000"

--- a/identity/control-plane/docs/03_next_steps.md
+++ b/identity/control-plane/docs/03_next_steps.md
@@ -11,3 +11,8 @@
 3) Add end-to-end trace propagation through PEP → PDP → receipts (trace_id + span_id stored).
 4) Add “path to OIDC” implementation plan and minimal Keycloak wiring.
 5) Add signature-ready receipts: keyless (future) and local key (dev) options.
+
+## Contract coverage (status)
+- OpenAPI now includes receipts POST/verify, receipts export, and policies active endpoints.
+- Error responses document `x-umbra-request-id` header and a flexible error envelope shape.
+- Keep contract updates aligned with service behavior and UI clients.

--- a/identity/control-plane/docs/api/openapi.yaml
+++ b/identity/control-plane/docs/api/openapi.yaml
@@ -36,18 +36,27 @@ paths:
                 $ref: '#/components/schemas/DecisionResponse'
         '400':
           description: Invalid request
+          headers:
+            x-umbra-request-id:
+              $ref: '#/components/headers/RequestId'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Policy evaluation error
+          headers:
+            x-umbra-request-id:
+              $ref: '#/components/headers/RequestId'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '503':
           description: PDP unavailable
+          headers:
+            x-umbra-request-id:
+              $ref: '#/components/headers/RequestId'
           content:
             application/json:
               schema:
@@ -137,6 +146,37 @@ paths:
                 properties:
                   ok: { type: boolean }
 
+  /v1/policies/active:
+    get:
+      tags: [policies]
+      summary: Get active policy (tenant-scoped)
+      operationId: getActivePolicy
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivePolicyResponse'
+        '404':
+          description: No active policy
+          headers:
+            x-umbra-request-id:
+              $ref: '#/components/headers/RequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Storage unavailable
+          headers:
+            x-umbra-request-id:
+              $ref: '#/components/headers/RequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /v1/policies/simulate:
     post:
       tags: [policies]
@@ -183,6 +223,79 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReceiptList'
+    post:
+      tags: [receipts]
+      summary: Ingest a receipt (tenant-scoped)
+      operationId: createReceipt
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReceiptIngestRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReceiptIngestResponse'
+        '400':
+          description: Invalid request
+          headers:
+            x-umbra-request-id:
+              $ref: '#/components/headers/RequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Storage error
+          headers:
+            x-umbra-request-id:
+              $ref: '#/components/headers/RequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /v1/receipts/verify:
+    post:
+      tags: [receipts]
+      summary: Verify receipt hash chain
+      operationId: verifyReceipts
+      parameters:
+        - in: query
+          name: kind
+          schema: { type: string, enum: [decision, invocation, all], default: all }
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 500, default: 100 }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReceiptVerifyResponse'
+        '400':
+          description: Invalid request
+          headers:
+            x-umbra-request-id:
+              $ref: '#/components/headers/RequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Storage error
+          headers:
+            x-umbra-request-id:
+              $ref: '#/components/headers/RequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /v1/receipts/export:
     get:
@@ -229,23 +342,39 @@ paths:
                 type: string
         '400':
           description: Invalid request
+          headers:
+            x-umbra-request-id:
+              $ref: '#/components/headers/RequestId'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
 components:
+  headers:
+    RequestId:
+      description: Correlation ID for the request (also present in response body when applicable).
+      schema:
+        type: string
   schemas:
     ErrorResponse:
       type: object
       properties:
         error_code:
           type: string
-          enum: [POLICY_DENIED, POLICY_INVALID, POLICY_UNAVAILABLE]
+          description: Stable error identifier (service-specific until error-envelope work is complete).
         message: { type: string }
         request_id: { type: string }
         decision_id: { type: string }
         trace_id: { type: string }
+        errors:
+          type: array
+          description: Optional field-level validation issues.
+          items:
+            type: object
+            properties:
+              field: { type: string }
+              message: { type: string }
       required: [error_code, message]
 
     TenantContext:
@@ -405,6 +534,16 @@ components:
         policy_version: { type: integer }
       required: [decision, reason]
 
+    ActivePolicyResponse:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        version: { type: integer }
+        policy_hash: { type: string }
+        updated_at: { type: string, format: date-time }
+      required: [id, name, version, policy_hash, updated_at]
+
     ReceiptList:
       type: object
       properties:
@@ -446,3 +585,74 @@ components:
         receipt_hash: { type: string }
         receipt_prev_hash: { type: string }
       required: [schema_version, kind, ts, receipt_hash]
+
+    ReceiptIngestRequest:
+      oneOf:
+        - $ref: '#/components/schemas/DecisionReceiptIngest'
+        - $ref: '#/components/schemas/InvocationReceiptIngest'
+      discriminator:
+        propertyName: kind
+
+    ReceiptIngestResponse:
+      type: object
+      properties:
+        receipt_id: { type: string }
+        hash: { type: string }
+        prev_hash: { type: string }
+      required: [receipt_id, hash]
+
+    ReceiptVerifyFailure:
+      type: object
+      properties:
+        receipt_id: { type: string }
+        code: { type: string }
+      required: [receipt_id, code]
+
+    ReceiptVerifyResponse:
+      type: object
+      properties:
+        ok: { type: boolean }
+        checked: { type: integer }
+        kind: { type: string, enum: [decision, invocation, all] }
+        failure:
+          $ref: '#/components/schemas/ReceiptVerifyFailure'
+      required: [ok, checked, kind]
+
+    ReceiptIngestBase:
+      type: object
+      properties:
+        kind: { type: string, enum: [decision, invocation] }
+        request_id: { type: string }
+        decision_id: { type: string }
+        trace_id: { type: string }
+        span_id: { type: string }
+        body:
+          type: object
+          description: |
+            Redacted receipt payload (no raw tool args by default).
+      required: [kind, request_id, body]
+
+    DecisionReceiptIngest:
+      allOf:
+        - $ref: '#/components/schemas/ReceiptIngestBase'
+        - type: object
+          properties:
+            decision: { type: string, enum: [allow, deny] }
+            policy_hash: { type: string }
+            policy_version: { type: integer }
+          required: [decision, policy_hash]
+
+    InvocationReceiptIngest:
+      allOf:
+        - $ref: '#/components/schemas/ReceiptIngestBase'
+        - type: object
+          properties:
+            tool_name: { type: string }
+            method: { type: string }
+            path: { type: string }
+            outcome: { type: string, enum: [success, error, denied] }
+            status_code: { type: integer }
+            latency_ms: { type: integer }
+            policy_hash: { type: string }
+            policy_version: { type: integer }
+          required: [tool_name, method, path, outcome, latency_ms]

--- a/identity/control-plane/docs/how-to-develop.md
+++ b/identity/control-plane/docs/how-to-develop.md
@@ -12,6 +12,18 @@ make dev
 make seed
 ```
 
+Optional: auto-seed the UI tenant
+Set `NEXT_PUBLIC_TENANT_ID` before starting the UI so the console auto-selects a tenant:
+```bash
+export NEXT_PUBLIC_TENANT_ID="<tenant-id-from-seed>"
+```
+
+Stopping the stack
+```bash
+docker compose -f deployments/docker-compose.yml down
+```
+Use `down -v` if you also want to wipe volumes and seeded data.
+
 ## Services
 - controlplane-api: http://localhost:8080
 - pdp: http://localhost:8081

--- a/identity/control-plane/docs/runbooks/demo.md
+++ b/identity/control-plane/docs/runbooks/demo.md
@@ -13,6 +13,13 @@ The seed script prints two tenant IDs:
 
 Copy one of them for the `x-umbra-tenant-id` header.
 
+Optional: auto-seed the UI tenant
+Set `NEXT_PUBLIC_TENANT_ID` before starting the UI so the console auto-selects a tenant:
+```bash
+export NEXT_PUBLIC_TENANT_ID="<tenant-id-from-seed>"
+```
+If you run the UI via Docker Compose, set `NEXT_PUBLIC_TENANT_ID` in an override file or your shell before `make dev`.
+
 ## 1) Verify health
 ```bash
 curl http://localhost:8080/healthz

--- a/identity/control-plane/services/pdp/internal/http-api/contract_test.go
+++ b/identity/control-plane/services/pdp/internal/http-api/contract_test.go
@@ -78,8 +78,12 @@ func TestDecisionContractOpenAPI(t *testing.T) {
 	assertInSet(t, decisionEnum, "allow", "deny")
 
 	errResp := derefSchema(t, spec, spec.Components.Schemas["ErrorResponse"])
-	codeEnum := set(errResp.Properties["error_code"].Enum)
-	assertInSet(t, codeEnum, "POLICY_DENIED", "POLICY_INVALID", "POLICY_UNAVAILABLE")
+	if errResp.Properties["error_code"] == nil {
+		t.Fatalf("missing error_code property in ErrorResponse")
+	}
+	if errResp.Properties["error_code"].Type != "" && errResp.Properties["error_code"].Type != "string" {
+		t.Fatalf("expected error_code to be string, got %q", errResp.Properties["error_code"].Type)
+	}
 
 	op := spec.Paths["/v1/decision"].Post
 	if op == nil {

--- a/identity/control-plane/ui/app/api/controlplane/[...path]/route.ts
+++ b/identity/control-plane/ui/app/api/controlplane/[...path]/route.ts
@@ -1,0 +1,55 @@
+const CONTROLPLANE_URL =
+  process.env.CONTROLPLANE_API_URL?.replace(/\/$/, "") || "http://localhost:8080";
+
+async function proxy(request: Request, params: { path?: string[] }) {
+  const targetPath = params.path?.join("/") || "";
+  const incomingUrl = new URL(request.url);
+  const targetUrl = new URL(`${CONTROLPLANE_URL}/${targetPath}`);
+  targetUrl.search = incomingUrl.search;
+
+  const headers = new Headers(request.headers);
+  headers.delete("host");
+
+  let body: ArrayBuffer | null = null;
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    body = await request.arrayBuffer();
+  }
+
+  const resp = await fetch(targetUrl, {
+    method: request.method,
+    headers,
+    body,
+  });
+
+  if (!resp.ok) {
+    console.error("controlplane proxy error", {
+      status: resp.status,
+      path: `/${targetPath}`,
+    });
+  }
+
+  return new Response(resp.body, {
+    status: resp.status,
+    headers: resp.headers,
+  });
+}
+
+export async function GET(request: Request, ctx: { params: { path?: string[] } }) {
+  return proxy(request, ctx.params);
+}
+
+export async function POST(request: Request, ctx: { params: { path?: string[] } }) {
+  return proxy(request, ctx.params);
+}
+
+export async function PUT(request: Request, ctx: { params: { path?: string[] } }) {
+  return proxy(request, ctx.params);
+}
+
+export async function PATCH(request: Request, ctx: { params: { path?: string[] } }) {
+  return proxy(request, ctx.params);
+}
+
+export async function DELETE(request: Request, ctx: { params: { path?: string[] } }) {
+  return proxy(request, ctx.params);
+}

--- a/identity/control-plane/ui/app/receipts/page.tsx
+++ b/identity/control-plane/ui/app/receipts/page.tsx
@@ -43,9 +43,10 @@ export default function ReceiptsPage() {
     try {
       const qValue = q.trim();
       const beforeValue = reset ? undefined : nextBefore;
+      const kindValue = kind === "all" ? undefined : kind;
       const data = await api.listReceipts({
         limit: 50,
-        kind,
+        ...(kindValue ? { kind: kindValue } : {}),
         ...(qValue ? { q: qValue } : {}),
         ...(beforeValue ? { before: beforeValue } : {}),
       }, signal);

--- a/identity/control-plane/ui/components/app/tenant-switcher.tsx
+++ b/identity/control-plane/ui/components/app/tenant-switcher.tsx
@@ -7,13 +7,8 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Badge } from "@/components/ui/badge";
 
 const STORAGE_KEY = "umbra.tenant_id";
-const LEGACY_STORAGE_KEY = "umbra.tenant";
 function getInitialTenant() {
   if (typeof window === "undefined") return "";
-  if (window.localStorage.getItem(LEGACY_STORAGE_KEY)) {
-    console.warn("Legacy tenant key found; use umbra.tenant_id going forward.");
-    window.localStorage.removeItem(LEGACY_STORAGE_KEY);
-  }
   const existing = window.localStorage.getItem(STORAGE_KEY);
   if (existing) return existing;
   const seeded = process.env.NEXT_PUBLIC_TENANT_ID || "";

--- a/identity/control-plane/ui/components/app/tenant-switcher.tsx
+++ b/identity/control-plane/ui/components/app/tenant-switcher.tsx
@@ -7,10 +7,21 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Badge } from "@/components/ui/badge";
 
 const STORAGE_KEY = "umbra.tenant_id";
-
+const LEGACY_STORAGE_KEY = "umbra.tenant";
 function getInitialTenant() {
   if (typeof window === "undefined") return "";
-  return window.localStorage.getItem(STORAGE_KEY) || "";
+  if (window.localStorage.getItem(LEGACY_STORAGE_KEY)) {
+    console.warn("Legacy tenant key found; use umbra.tenant_id going forward.");
+    window.localStorage.removeItem(LEGACY_STORAGE_KEY);
+  }
+  const existing = window.localStorage.getItem(STORAGE_KEY);
+  if (existing) return existing;
+  const seeded = process.env.NEXT_PUBLIC_TENANT_ID || "";
+  if (seeded) {
+    window.localStorage.setItem(STORAGE_KEY, seeded);
+    return seeded;
+  }
+  return "";
 }
 
 export default function TenantSwitcher({ compact = false }: { compact?: boolean }) {

--- a/identity/control-plane/ui/lib/api.ts
+++ b/identity/control-plane/ui/lib/api.ts
@@ -1,18 +1,19 @@
 import type { ListResponse, PolicyRow, Receipt, Tool } from "./types";
 
-const BASE_URL =
-  process.env.NEXT_PUBLIC_CONTROLPLANE_URL?.replace(/\/$/, "") || "http://localhost:8080";
+const BASE_URL = "/api/controlplane";
+const TENANT_KEY = "umbra.tenant_id";
 
 function getTenant(): string {
   if (typeof window === "undefined") return "";
-  return localStorage.getItem("umbra.tenant") || "";
+  return localStorage.getItem(TENANT_KEY) || "";
 }
 
 async function request<T>(path: string, opts: RequestInit = {}): Promise<T> {
   const headers: Record<string, string> = {
     ...(opts.headers ? (opts.headers as Record<string, string>) : {}),
-    "x-umbra-tenant-id": getTenant(),
   };
+  const tenant = getTenant();
+  if (tenant) headers["x-umbra-tenant-id"] = tenant;
   const res = await fetch(`${BASE_URL}${path}`, { ...opts, headers });
   if (!res.ok) {
     const text = await res.text().catch(() => "");
@@ -63,7 +64,7 @@ export const api = {
   ) => {
     const sp = new URLSearchParams();
     sp.set("limit", String(params.limit ?? 100));
-    if (params.kind) sp.set("kind", params.kind);
+    if (params.kind && params.kind !== "all") sp.set("kind", params.kind);
     if (params.q) sp.set("q", params.q);
     if (params.before) sp.set("before", params.before);
     return request<ListResponse<Receipt>>(

--- a/identity/control-plane/ui/package.json
+++ b/identity/control-plane/ui/package.json
@@ -11,31 +11,31 @@
     "format": "prettier -w ."
   },
   "dependencies": {
-    "next": "14.2.13",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "lucide-react": "0.462.0",
-    "clsx": "2.1.1",
-    "tailwind-merge": "2.5.4",
-    "class-variance-authority": "0.7.0",
     "@radix-ui/react-dialog": "1.1.2",
     "@radix-ui/react-dropdown-menu": "2.1.2",
     "@radix-ui/react-select": "2.1.2",
     "@radix-ui/react-separator": "1.1.0",
     "@radix-ui/react-slot": "1.1.0",
+    "class-variance-authority": "0.7.0",
+    "clsx": "2.1.1",
+    "lucide-react": "0.462.0",
+    "next": "14.2.35",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "tailwind-merge": "2.5.4",
     "zod": "3.23.8"
   },
   "devDependencies": {
     "@types/node": "20.11.30",
     "@types/react": "18.3.3",
-    "eslint": "8.57.0",
-    "eslint-config-next": "14.2.13",
-    "prettier": "3.3.3",
-    "typescript": "5.5.4",
-    "tailwindcss": "3.4.14",
-    "postcss": "8.4.47",
-    "autoprefixer": "10.4.20",
     "@typescript-eslint/eslint-plugin": "7.18.0",
-    "@typescript-eslint/parser": "7.18.0"
+    "@typescript-eslint/parser": "7.18.0",
+    "autoprefixer": "10.4.20",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.35",
+    "postcss": "8.4.47",
+    "prettier": "3.3.3",
+    "tailwindcss": "3.4.14",
+    "typescript": "5.5.4"
   }
 }

--- a/identity/control-plane/ui/pnpm-lock.yaml
+++ b/identity/control-plane/ui/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 0.462.0
         version: 0.462.0(react@18.3.1)
       next:
-        specifier: 14.2.13
-        version: 14.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 14.2.35
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -67,8 +67,8 @@ importers:
         specifier: 8.57.0
         version: 8.57.0
       eslint-config-next:
-        specifier: 14.2.13
-        version: 14.2.13(eslint@8.57.0)(typescript@5.5.4)
+        specifier: 14.2.35
+        version: 14.2.35(eslint@8.57.0)(typescript@5.5.4)
       postcss:
         specifier: 8.4.47
         version: 8.4.47
@@ -163,62 +163,62 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@14.2.13':
-    resolution: {integrity: sha512-s3lh6K8cbW1h5Nga7NNeXrbe0+2jIIYK9YaA9T7IufDWnZpozdFUp6Hf0d5rNWUKu4fEuSX2rCKlGjCrtylfDw==}
+  '@next/env@14.2.35':
+    resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
 
-  '@next/eslint-plugin-next@14.2.13':
-    resolution: {integrity: sha512-z8Mk0VljxhIzsSiZUSdt3wp+t2lKd+jk5a9Jsvh3zDGkItgDMfjv/ZbET6HsxEl/fSihVoHGsXV6VLyDH0lfTQ==}
+  '@next/eslint-plugin-next@14.2.35':
+    resolution: {integrity: sha512-Jw9A3ICz2183qSsqwi7fgq4SBPiNfmOLmTPXKvlnzstUwyvBrtySiY+8RXJweNAs9KThb1+bYhZh9XWcNOr2zQ==}
 
-  '@next/swc-darwin-arm64@14.2.13':
-    resolution: {integrity: sha512-IkAmQEa2Htq+wHACBxOsslt+jMoV3msvxCn0WFSfJSkv/scy+i/EukBKNad36grRxywaXUYJc9mxEGkeIs8Bzg==}
+  '@next/swc-darwin-arm64@14.2.33':
+    resolution: {integrity: sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@14.2.13':
-    resolution: {integrity: sha512-Dv1RBGs2TTjkwEnFMVL5XIfJEavnLqqwYSD6LXgTPdEy/u6FlSrLBSSfe1pcfqhFEXRAgVL3Wpjibe5wXJzWog==}
+  '@next/swc-darwin-x64@14.2.33':
+    resolution: {integrity: sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@14.2.13':
-    resolution: {integrity: sha512-yB1tYEFFqo4ZNWkwrJultbsw7NPAAxlPXURXioRl9SdW6aIefOLS+0TEsKrWBtbJ9moTDgU3HRILL6QBQnMevg==}
+  '@next/swc-linux-arm64-gnu@14.2.33':
+    resolution: {integrity: sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@14.2.13':
-    resolution: {integrity: sha512-v5jZ/FV/eHGoWhMKYrsAweQ7CWb8xsWGM/8m1mwwZQ/sutJjoFaXchwK4pX8NqwImILEvQmZWyb8pPTcP7htWg==}
+  '@next/swc-linux-arm64-musl@14.2.33':
+    resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@14.2.13':
-    resolution: {integrity: sha512-aVc7m4YL7ViiRv7SOXK3RplXzOEe/qQzRA5R2vpXboHABs3w8vtFslGTz+5tKiQzWUmTmBNVW0UQdhkKRORmGA==}
+  '@next/swc-linux-x64-gnu@14.2.33':
+    resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@14.2.13':
-    resolution: {integrity: sha512-4wWY7/OsSaJOOKvMsu1Teylku7vKyTuocvDLTZQq0TYv9OjiYYWt63PiE1nTuZnqQ4RPvME7Xai+9enoiN0Wrg==}
+  '@next/swc-linux-x64-musl@14.2.33':
+    resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@14.2.13':
-    resolution: {integrity: sha512-uP1XkqCqV2NVH9+g2sC7qIw+w2tRbcMiXFEbMihkQ8B1+V6m28sshBwAB0SDmOe0u44ne1vFU66+gx/28RsBVQ==}
+  '@next/swc-win32-arm64-msvc@14.2.33':
+    resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-ia32-msvc@14.2.13':
-    resolution: {integrity: sha512-V26ezyjPqQpDBV4lcWIh8B/QICQ4v+M5Bo9ykLN+sqeKKBxJVDpEc6biDVyluTXTC40f5IqCU0ttth7Es2ZuMw==}
+  '@next/swc-win32-ia32-msvc@14.2.33':
+    resolution: {integrity: sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@14.2.13':
-    resolution: {integrity: sha512-WwzOEAFBGhlDHE5Z73mNU8CO8mqMNLqaG+AO9ETmzdCQlJhVtWZnOl2+rqgVQS+YHunjOWptdFmNfbpwcUuEsw==}
+  '@next/swc-win32-x64-msvc@14.2.33':
+    resolution: {integrity: sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -611,6 +611,14 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/eslint-plugin@8.51.0':
+    resolution: {integrity: sha512-XtssGWJvypyM2ytBnSnKtHYOGT+4ZwTnBVl36TA4nRO2f4PRNGz5/1OszHzcZCvcBMh+qb7I06uoCmLTRdR9og==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.51.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/parser@7.18.0':
     resolution: {integrity: sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -621,9 +629,32 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/parser@8.51.0':
+    resolution: {integrity: sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.51.0':
+    resolution: {integrity: sha512-Luv/GafO07Z7HpiI7qeEW5NW8HUtZI/fo/kE0YbtQEFpJRUuR0ajcWfCE5bnMvL7QQFrmT/odMe8QZww8X2nfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/scope-manager@7.18.0':
     resolution: {integrity: sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/scope-manager@8.51.0':
+    resolution: {integrity: sha512-JhhJDVwsSx4hiOEQPeajGhCWgBMBwVkxC/Pet53EpBVs7zHHtayKefw1jtPaNRXpI9RA2uocdmpdfE7T+NrizA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.51.0':
+    resolution: {integrity: sha512-Qi5bSy/vuHeWyir2C8u/uqGMIlIDu8fuiYWv48ZGlZ/k+PRPHtaAu7erpc7p5bzw2WNNSniuxoMSO4Ar6V9OXw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/type-utils@7.18.0':
     resolution: {integrity: sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==}
@@ -635,9 +666,20 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/type-utils@8.51.0':
+    resolution: {integrity: sha512-0XVtYzxnobc9K0VU7wRWg1yiUrw4oQzexCG2V2IDxxCxhqBMSMbjB+6o91A+Uc0GWtgjCa3Y8bi7hwI0Tu4n5Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/types@7.18.0':
     resolution: {integrity: sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/types@8.51.0':
+    resolution: {integrity: sha512-TizAvWYFM6sSscmEakjY3sPqGwxZRSywSsPEiuZF6d5GmGD9Gvlsv0f6N8FvAAA0CD06l3rIcWNbsN1e5F/9Ag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@7.18.0':
     resolution: {integrity: sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==}
@@ -648,15 +690,32 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@8.51.0':
+    resolution: {integrity: sha512-1qNjGqFRmlq0VW5iVlcyHBbCjPB7y6SxpBkrbhNWMy/65ZoncXCEPJxkRZL8McrseNH6lFhaxCIaX+vBuFnRng==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/utils@7.18.0':
     resolution: {integrity: sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
 
+  '@typescript-eslint/utils@8.51.0':
+    resolution: {integrity: sha512-11rZYxSe0zabiKaCP2QAwRf/dnmgFgvTmeDTtZvUvXG3UuAdg/GU02NExmmIXzz3vLGgMdtrIosI84jITQOxUA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/visitor-keys@7.18.0':
     resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/visitor-keys@8.51.0':
+    resolution: {integrity: sha512-mM/JRQOzhVN1ykejrvwnBRV3+7yTKK8tVANVN3o1O0t0v7o+jqdVu9crPy5Y9dov15TJk/FTIgoUGHrTOVL3Zg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -1089,8 +1148,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@14.2.13:
-    resolution: {integrity: sha512-aro1EKAoyYchnO/3Tlo91hnNBO7QO7qnv/79MAFC+4Jq8TdUVKQlht5d2F+YjrePjdpOvfL+mV9JPfyYNwkk1g==}
+  eslint-config-next@14.2.35:
+    resolution: {integrity: sha512-BpLsv01UisH193WyT/1lpHqq5iJ/Orfz9h/NOOlAmTUq4GY349PextQ62K4XpnaM9supeiEn3TaOTeQO07gURg==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
       typescript: '>=3.3.1'
@@ -1170,6 +1229,10 @@ packages:
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
@@ -1361,6 +1424,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   import-fresh@3.3.1:
@@ -1628,10 +1695,9 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@14.2.13:
-    resolution: {integrity: sha512-BseY9YNw8QJSwLYD7hlZzl6QVDoSFHL/URN5K64kVEVpCsSOWeyjbIGK+dZUaRViHTaMQX8aqmnn0PHBbGZezg==}
+  next@14.2.35:
+    resolution: {integrity: sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==}
     engines: {node: '>=18.17.0'}
-    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -2100,6 +2166,12 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
+  ts-api-utils@2.3.0:
+    resolution: {integrity: sha512-6eg3Y9SF7SsAvGzRHQvvc1skDAhwI4YQ32ui1scxD1Ccr0G5qIIbUBT3pFTKX8kmWIQClHobtUdNuaBgwdfdWg==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -2330,37 +2402,37 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@14.2.13': {}
+  '@next/env@14.2.35': {}
 
-  '@next/eslint-plugin-next@14.2.13':
+  '@next/eslint-plugin-next@14.2.35':
     dependencies:
       glob: 10.3.10
 
-  '@next/swc-darwin-arm64@14.2.13':
+  '@next/swc-darwin-arm64@14.2.33':
     optional: true
 
-  '@next/swc-darwin-x64@14.2.13':
+  '@next/swc-darwin-x64@14.2.33':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@14.2.13':
+  '@next/swc-linux-arm64-gnu@14.2.33':
     optional: true
 
-  '@next/swc-linux-arm64-musl@14.2.13':
+  '@next/swc-linux-arm64-musl@14.2.33':
     optional: true
 
-  '@next/swc-linux-x64-gnu@14.2.13':
+  '@next/swc-linux-x64-gnu@14.2.33':
     optional: true
 
-  '@next/swc-linux-x64-musl@14.2.13':
+  '@next/swc-linux-x64-musl@14.2.33':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@14.2.13':
+  '@next/swc-win32-arm64-msvc@14.2.33':
     optional: true
 
-  '@next/swc-win32-ia32-msvc@14.2.13':
+  '@next/swc-win32-ia32-msvc@14.2.33':
     optional: true
 
-  '@next/swc-win32-x64-msvc@14.2.13':
+  '@next/swc-win32-x64-msvc@14.2.33':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -2727,6 +2799,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.51.0(@typescript-eslint/parser@8.51.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.51.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/scope-manager': 8.51.0
+      '@typescript-eslint/type-utils': 8.51.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.51.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/visitor-keys': 8.51.0
+      eslint: 8.57.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.3.0(typescript@5.5.4)
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
@@ -2740,10 +2828,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.51.0(eslint@8.57.0)(typescript@5.5.4)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.51.0
+      '@typescript-eslint/types': 8.51.0
+      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.5.4)
+      '@typescript-eslint/visitor-keys': 8.51.0
+      debug: 4.4.3
+      eslint: 8.57.0
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.51.0(typescript@5.5.4)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.51.0(typescript@5.5.4)
+      '@typescript-eslint/types': 8.51.0
+      debug: 4.4.3
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
+
+  '@typescript-eslint/scope-manager@8.51.0':
+    dependencies:
+      '@typescript-eslint/types': 8.51.0
+      '@typescript-eslint/visitor-keys': 8.51.0
+
+  '@typescript-eslint/tsconfig-utils@8.51.0(typescript@5.5.4)':
+    dependencies:
+      typescript: 5.5.4
 
   '@typescript-eslint/type-utils@7.18.0(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
@@ -2757,7 +2875,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.51.0(eslint@8.57.0)(typescript@5.5.4)':
+    dependencies:
+      '@typescript-eslint/types': 8.51.0
+      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.51.0(eslint@8.57.0)(typescript@5.5.4)
+      debug: 4.4.3
+      eslint: 8.57.0
+      ts-api-utils: 2.3.0(typescript@5.5.4)
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@7.18.0': {}
+
+  '@typescript-eslint/types@8.51.0': {}
 
   '@typescript-eslint/typescript-estree@7.18.0(typescript@5.5.4)':
     dependencies:
@@ -2774,6 +2906,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.51.0(typescript@5.5.4)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.51.0(typescript@5.5.4)
+      '@typescript-eslint/tsconfig-utils': 8.51.0(typescript@5.5.4)
+      '@typescript-eslint/types': 8.51.0
+      '@typescript-eslint/visitor-keys': 8.51.0
+      debug: 4.4.3
+      minimatch: 9.0.5
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.3.0(typescript@5.5.4)
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@7.18.0(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.0)
@@ -2785,10 +2932,26 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@8.51.0(eslint@8.57.0)(typescript@5.5.4)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 8.51.0
+      '@typescript-eslint/types': 8.51.0
+      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.5.4)
+      eslint: 8.57.0
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@8.51.0':
+    dependencies:
+      '@typescript-eslint/types': 8.51.0
+      eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -3262,16 +3425,16 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@14.2.13(eslint@8.57.0)(typescript@5.5.4):
+  eslint-config-next@14.2.35(eslint@8.57.0)(typescript@5.5.4):
     dependencies:
-      '@next/eslint-plugin-next': 14.2.13
+      '@next/eslint-plugin-next': 14.2.35
       '@rushstack/eslint-patch': 1.15.0
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 8.51.0(@typescript-eslint/parser@8.51.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.51.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
       eslint-plugin-react: 7.37.5(eslint@8.57.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.0)
@@ -3301,22 +3464,21 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3327,7 +3489,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -3396,6 +3558,8 @@ snapshots:
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
 
   eslint@8.57.0:
     dependencies:
@@ -3634,6 +3798,8 @@ snapshots:
       function-bind: 1.1.2
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -3891,9 +4057,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@14.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 14.2.13
+      '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
       caniuse-lite: 1.0.30001762
@@ -3903,15 +4069,15 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.1(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.13
-      '@next/swc-darwin-x64': 14.2.13
-      '@next/swc-linux-arm64-gnu': 14.2.13
-      '@next/swc-linux-arm64-musl': 14.2.13
-      '@next/swc-linux-x64-gnu': 14.2.13
-      '@next/swc-linux-x64-musl': 14.2.13
-      '@next/swc-win32-arm64-msvc': 14.2.13
-      '@next/swc-win32-ia32-msvc': 14.2.13
-      '@next/swc-win32-x64-msvc': 14.2.13
+      '@next/swc-darwin-arm64': 14.2.33
+      '@next/swc-darwin-x64': 14.2.33
+      '@next/swc-linux-arm64-gnu': 14.2.33
+      '@next/swc-linux-arm64-musl': 14.2.33
+      '@next/swc-linux-x64-gnu': 14.2.33
+      '@next/swc-linux-x64-musl': 14.2.33
+      '@next/swc-win32-arm64-msvc': 14.2.33
+      '@next/swc-win32-ia32-msvc': 14.2.33
+      '@next/swc-win32-x64-msvc': 14.2.33
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -4416,6 +4582,10 @@ snapshots:
       is-number: 7.0.0
 
   ts-api-utils@1.4.3(typescript@5.5.4):
+    dependencies:
+      typescript: 5.5.4
+
+  ts-api-utils@2.3.0(typescript@5.5.4):
     dependencies:
       typescript: 5.5.4
 


### PR DESCRIPTION
UI demo reliability + OpenAPI coverage updates + Next.js security bump
Fixes Issue: https://github.com/srehcs/umbra/issues/26
Summary:

- Added same‑origin API proxy and standardized tenant handling to prevent CORS/tenant issues in the UI demo flow.
- Updated receipts filtering and related UI logic to avoid invalid kind=all queries.
- Expanded OpenAPI coverage (receipts ingest/verify, policies active) and documented error headers/envelope.
- Updated demo/developer docs with tenant auto‑seed guidance and stack stop instructions.
- Upgraded Next.js to 14.2.35 and aligned eslint-config-next.

Verification:

- pnpm build and pnpm lint in identity/control-plane/ui
- Manual UI check: Tools/Policies/Receipts load with seeded tenant; requests go to /api/controlplane and include x-umbra-tenant-id. (docker --> make dev and make seed --> then curl the tenant. if you dont you'll get an error).