### PR TITLE
Feature: Rust Gateway + Other Issue Resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Repo path: `identity/control-plane/`
 Core components:
 - UI (Next.js + ShadCN): `identity/control-plane/ui/`
 - Services (Go): `identity/control-plane/services/`
+- Optional Rust PEP (MCP-first gateway): `identity/control-plane/services/pep-rust/`
 - Shared packages: `identity/control-plane/packages/`
 - Docs (C4, OpenAPI, threat model): `identity/control-plane/docs/`
 - ADRs (centralized): `docs/adr/`
@@ -53,6 +54,22 @@ From the repo root:
 cd identity/control-plane
 make dev
 make seed
+```
+
+For a minimal stack (UI + API + PDP only):
+
+```bash
+cd identity/control-plane
+make dev-min
+```
+
+`make dev` enables the `obs` profile by default (Redis + OTel Collector + Jaeger).
+
+To include the Rust PEP gateway in the local stack:
+
+```bash
+cd identity/control-plane
+COMPOSE_PROFILES=rust-pep make dev
 ```
 
 Then open:

--- a/RULES.md
+++ b/RULES.md
@@ -20,6 +20,39 @@ See: `docs/how-to-develop.md` for the “golden path” workflow used by this sc
 - UI fetches must be abortable; cancel stale requests on unmount or filter changes.
 - UI should avoid expensive render-time serialization (e.g., JSON.stringify in render); memoize or lazy-render.
 
+## Rust standards
+- Prefer safe Rust; no `unsafe` in request paths without explicit justification and isolation.
+- Use `clippy` clean builds (`cargo clippy -- -D warnings`) for new Rust services.
+- Enforce timeouts and bounded concurrency on outbound calls.
+- Avoid blocking in async paths; use `spawn_blocking` for CPU-heavy or blocking I/O.
+- Use bounded channels/queues; avoid unbounded buffers without backpressure.
+- Avoid logging sensitive data; redact in receipts and logs.
+
+## Go standards
+- Keep request handlers thin; move domain logic into package-level services.
+- Always propagate `context.Context`; honor cancellations/timeouts on I/O.
+- Return typed errors; map to `{ error: { code, message }, request_id }` at boundaries.
+- Avoid global mutable state; inject deps for testability.
+- Use `sql`/`pgx` with explicit columns; avoid `SELECT *` in query paths.
+- Validate input at API edges; keep internal structs trusted and minimal.
+
+## TypeScript standards
+- Strict typing on; prefer `unknown` over `any`, and avoid `as` casts unless documented and isolated.
+- OpenAPI types are first-class contracts; use Zod for runtime validation where inputs can be untrusted.
+- Zod schemas are the contract at boundaries; infer types from schemas and validate runtime inputs.
+- Keep API clients centralized; no ad-hoc `fetch` scattered across pages.
+- Prefer server-side data fetching when inputs are cacheable or not user-specific; use client fetches when driven by client-only state or interactivity.
+- Avoid repeated derived computation in render; memoize heavy transforms.
+- Never log secrets or full payloads; redact before emitting telemetry.
+
+## Advanced systems practices
+- Deterministic canonicalization with test vectors (cross-language reproducibility).
+- Signed receipts with rotation plan (KMS-backed) and signature metadata in schema.
+- Idempotency and replay protection via `request_id` (dedupe semantics documented).
+- Streaming exports with backpressure and bounded memory (JSONL/CSV).
+- Property-based/fuzz tests for parsing, canonicalization, and policy evaluation.
+- Contract tests across services with schema versioning and golden payloads.
+
 ## UI standards
 - Prefer shared UI components under `identity/control-plane/ui/components/ui/`; add a component there instead of raw elements when standardizing behavior.
 

--- a/docs/adr/0011-optional-rust-pep-compose-profile.md
+++ b/docs/adr/0011-optional-rust-pep-compose-profile.md
@@ -1,0 +1,33 @@
+# ADR-0011: Optional Rust PEP via Docker Compose profile
+
+- Status: accepted
+- Date: 2026-01-02
+- Owners: Umbra team
+
+## Context
+The Rust PEP is an optional service alongside the Go control plane. The default local stack (`make dev`) builds all services in the compose file, which forces Rust toolchain downloads even when a developer only needs the Go services and UI. This slows onboarding and adds friction for contributors working on non-Rust areas.
+
+We still want a clear path to run the Rust PEP when:
+- We need MCP-first enforcement behavior (protocol focus, low overhead).
+- We want a second language implementation to validate cross-service contracts.
+- We are testing production-oriented performance/latency characteristics for the gateway.
+
+## Decision
+Mark `pep-rust` behind a Docker Compose profile named `rust-pep`. The service is opt-in via `COMPOSE_PROFILES=rust-pep` when needed, while the default stack remains Go services + UI.
+
+Why use the Rust PEP:
+- Lower-latency, single-binary gateway for MCP tool calls.
+- Easier to embed or run as a sidecar in edge deployments.
+- Useful for cross-implementation parity testing with the Go PEP gateway.
+
+
+## Alternatives considered
+1) Keep a single compose file and rely on ad-hoc `docker compose up` service lists.
+2) Split into multiple compose files (core + optional).
+3) Remove Rust PEP from local stack entirely and require manual build/run.
+
+## Consequences
+- Positive: Default dev flow avoids Rust dependency downloads; optional service is explicit and documented.
+- Positive: Keeps the Rust PEP available for performance testing and protocol parity.
+- Negative: Developers must opt in when they want the Rust PEP.
+- Follow-ups: Document `make dev-rust` in READMEs and developer docs.

--- a/docs/adr/0012-minimal-dev-stack-target.md
+++ b/docs/adr/0012-minimal-dev-stack-target.md
@@ -1,0 +1,41 @@
+# ADR-0012: Minimal dev stack target (make dev-min)
+
+- Status: accepted
+- Date: 2026-01-02
+- Owners: Umbra team
+
+## Context
+The full local stack includes enforcement and demo services that are not required for basic UI, policy, and receipt workflows. Contributors working on the control plane UI/API should be able to avoid starting optional services and their dependencies.
+
+## Decision
+Add a `make dev-min` target that starts the minimum local stack: UI, controlplane-api, PDP, and their required dependencies. Optional services (PEP, MCP demo services, observability extras) remain available via the full `make dev` or explicit opt-in targets.
+
+Container breakdown:
+- Included (dev-min):
+  - `postgres` — primary database
+  - `controlplane-api` — admin API for tools, policies, receipts
+  - `pdp` — policy decision point (allow/deny)
+  - `ui` — Next.js control plane console
+- Excluded (dev-min):
+  - `redis` — caching/eventing dependency (optional in dev)
+  - `otel-collector` — OpenTelemetry collector (observability pipeline)
+  - `jaeger` — local trace viewer (observability UI)
+  - `pep-gateway` — enforcement proxy for tool calls
+  - `mcp-adapter` — MCP-facing enforcement adapter
+  - `mcp-upstream` — MCP test upstream service
+  - `upstream-sample` — demo upstream for PEP forwarding
+  - `pep-rust` — Rust PEP gateway (optional profile)
+
+Observability profile:
+- `make dev` enables the `obs` profile by default (Redis + OTel Collector + Jaeger).
+- `make dev-min` runs without `obs` (no extra containers).
+
+## Alternatives considered
+1) Keep a single `make dev` flow for all contributors.
+2) Maintain a separate compose file for minimal services.
+
+## Consequences
+- Positive: Faster local startup and lower resource usage for common UI/API work.
+- Positive: Clear separation between core control-plane workflows and optional demo/enforcement services.
+- Negative: Contributors may need to switch targets when they start testing enforcement flows.
+- Follow-ups: Keep developer docs and READMEs in sync with the `dev-min` target.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,3 +23,5 @@ This directory is the single source of truth for architectural decisions across 
 - `0008-pep-integration-pattern.md` — PEP integration pattern (HTTP proxy / ext_authz)
 - `0009-identity-provider-claims-model.md` — Identity provider choice and claims model
 - `0010-typed-api-contracts-and-e2e.md` — Typed OpenAPI contracts and E2E harness
+- `0011-optional-rust-pep-compose-profile.md` — Optional Rust PEP via Docker Compose profile
+- `0012-minimal-dev-stack-target.md` — Minimal dev stack target (make dev-min)

--- a/identity/control-plane/Makefile
+++ b/identity/control-plane/Makefile
@@ -62,6 +62,7 @@ migrate:
 	@docker compose -f deployments/docker-compose.yml exec -T postgres psql -U umbra -d umbra -v ON_ERROR_STOP=1 -f /migrations/0003_add_receipt_indexes.sql
 	@docker compose -f deployments/docker-compose.yml exec -T postgres psql -U umbra -d umbra -v ON_ERROR_STOP=1 -f /migrations/0004_add_receipt_search_indexes.sql
 	@docker compose -f deployments/docker-compose.yml exec -T postgres psql -U umbra -d umbra -v ON_ERROR_STOP=1 -f /migrations/0005_add_receipt_search_text.sql
+	@docker compose -f deployments/docker-compose.yml exec -T postgres psql -U umbra -d umbra -v ON_ERROR_STOP=1 -f /migrations/0006_add_receipt_canonical.sql
 
 verify:
 	@bash scripts/dev/verify_local.sh

--- a/identity/control-plane/Makefile
+++ b/identity/control-plane/Makefile
@@ -1,8 +1,16 @@
 SHELL := /bin/bash
 
 COMPOSE := docker compose -f deployments/docker-compose.yml
+COMPOSE_PROFILES ?= obs
 
-.PHONY: bootstrap fmt lint test gen up down logs dev seed docker-build verify migrate receipts-verify e2e-setup e2e e2e-fast e2e-local
+DEV_RUST_PROFILES := $(COMPOSE_PROFILES)
+ifneq ($(strip $(DEV_RUST_PROFILES)),)
+DEV_RUST_PROFILES := $(DEV_RUST_PROFILES),rust-pep
+else
+DEV_RUST_PROFILES := rust-pep
+endif
+
+.PHONY: bootstrap fmt lint test gen up down logs dev dev-min dev-rust seed docker-build verify migrate receipts-verify e2e-setup e2e e2e-fast e2e-local
 
 bootstrap:
 	@echo "Bootstrap: go mod tidy (optional) + ui deps"
@@ -39,7 +47,7 @@ seed:
 # Start local stack, wait for readiness, seed the DB, and print endpoints
 dev:
 	@mkdir -p ./local/.data/postgres
-	$(COMPOSE) up -d --build
+	@COMPOSE_PROFILES=$(COMPOSE_PROFILES) $(COMPOSE) up -d --build
 	@bash scripts/dev/wait_for_services.sh
 	@bash scripts/dev/seed_db.sh
 	@echo "\nLocal endpoints:"
@@ -47,6 +55,30 @@ dev:
 	@echo "API: http://localhost:8080"
 	@echo "PDP: http://localhost:8081"
 	@echo "PEP: http://localhost:8082"
+
+# Start minimal stack (UI + API + PDP + deps) without PEP/MCP services.
+dev-min:
+	@mkdir -p ./local/.data/postgres
+	@COMPOSE_PROFILES= $(COMPOSE) up -d --build controlplane-api pdp ui
+	@SKIP_PEP_WAIT=1 bash scripts/dev/wait_for_services.sh
+	@bash scripts/dev/seed_db.sh
+	@echo "\nLocal endpoints:"
+	@echo "UI:  http://localhost:3000"
+	@echo "API: http://localhost:8080"
+	@echo "PDP: http://localhost:8081"
+
+# Start local stack with optional services enabled (e.g., Rust PEP via profiles)
+dev-rust:
+	@mkdir -p ./local/.data/postgres
+	@COMPOSE_PROFILES=$(DEV_RUST_PROFILES) $(COMPOSE) up -d --build
+	@bash scripts/dev/wait_for_services.sh
+	@bash scripts/dev/seed_db.sh
+	@echo "\nLocal endpoints:"
+	@echo "UI:  http://localhost:3000"
+	@echo "API: http://localhost:8080"
+	@echo "PDP: http://localhost:8081"
+	@echo "PEP: http://localhost:8082"
+	@echo "Rust PEP: http://localhost:8084"
 
 # Check demo readiness (db, api, pdp, tools/policies, receipts)
 .PHONY: demo-check

--- a/identity/control-plane/README.md
+++ b/identity/control-plane/README.md
@@ -42,6 +42,7 @@ Open:
 
 Demo script:
 - `docs/runbooks/demo.md`
+- `docs/runbooks/security_demo.md`
 - PDP unavailable runbook: `docs/runbooks/pdp_unavailable.md`
 - Examples: `docs/examples/`
 
@@ -52,6 +53,7 @@ Demo script:
 Start here:
 - `docs/00_exec_summary.md`
 - `docs/runbooks/demo.md`
+- `docs/runbooks/security_demo.md`
 - `docs/runbooks/pdp_unavailable.md`
 
 Engineering rules (umbrella-level):
@@ -74,8 +76,3 @@ See `docs/api/openapi.yaml` for the full contract.
 - UI: `pnpm lint` (run from `identity/control-plane/ui`)
 
 ---
-
-## Technical details (legacy)
-
-We keep the original technical README here:
-- `README.legacy.md`

--- a/identity/control-plane/README.md
+++ b/identity/control-plane/README.md
@@ -25,6 +25,10 @@ Evaluates policies and returns **allow/deny** (plus obligations later).
 3) **Enforcement Gate (PEP Gateway)**  
 Intercepts tool calls, asks PDP, blocks or forwards, and always writes a receipt.
 
+Optional:
+4) **Rust PEP (MCP-first gateway)**  
+Standalone Rust PEP for low-latency MCP tool-call enforcement and parity testing.
+
 ---
 
 ## Quick start (local)
@@ -32,6 +36,26 @@ Intercepts tool calls, asks PDP, blocks or forwards, and always writes a receipt
 ```bash
 make dev
 make seed
+```
+
+For a minimal stack (UI + API + PDP only):
+
+```bash
+make dev-min
+```
+
+`make dev` enables the `obs` profile by default (Redis + OTel Collector + Jaeger).
+
+To include the Rust PEP gateway:
+
+```bash
+COMPOSE_PROFILES=rust-pep make dev
+```
+
+Or use the shortcut target:
+
+```bash
+make dev-rust
 ```
 
 Open:

--- a/identity/control-plane/deployments/docker-compose.yml
+++ b/identity/control-plane/deployments/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ../migrations:/migrations:ro
 
   redis:
+    profiles: ["obs"]
     image: redis:7
     ports:
       - "6379:6379"
@@ -32,11 +33,13 @@ services:
       - "8090:8090"
 
   jaeger:
+    profiles: ["obs"]
     image: jaegertracing/all-in-one:latest
     ports:
       - "16686:16686"
 
   otel-collector:
+    profiles: ["obs"]
     image: otel/opentelemetry-collector-contrib:0.108.0
     command: ["--config=/etc/otel-collector.yml"]
     volumes:
@@ -61,8 +64,6 @@ services:
       - "8080:8080"
     depends_on:
       - postgres
-      - redis
-      - otel-collector
 
   pdp:
     build:
@@ -78,8 +79,6 @@ services:
       - "8081:8081"
     depends_on:
       - postgres
-      - redis
-      - otel-collector
 
   pep-gateway:
     build:
@@ -123,6 +122,29 @@ services:
       - pdp
       - postgres
       - otel-collector
+      - mcp-upstream
+
+  pep-rust:
+    profiles: ["rust-pep"]
+    build:
+      context: ..
+      dockerfile: services/pep-rust/Dockerfile
+    environment:
+      PEP_MODE: observe
+      PDP_URL: http://pdp:8081
+      CONTROLPLANE_API_URL: http://controlplane-api:8080
+      MCP_UPSTREAM_URL: http://mcp-upstream:8090/mcp
+      MCP_TENANT_ID: 00000000-0000-0000-0000-000000000001
+      MCP_ACTOR_ID: user-1
+      MCP_ACTOR_TYPE: agent
+      MCP_ACTOR_ROLES: developer
+      MCP_SERVER_NAME: demo.mcp
+      PORT: "8084"
+    ports:
+      - "8084:8084"
+    depends_on:
+      - pdp
+      - controlplane-api
       - mcp-upstream
 
   ui:

--- a/identity/control-plane/docs/how-to-develop.md
+++ b/identity/control-plane/docs/how-to-develop.md
@@ -12,6 +12,27 @@ make dev
 make seed
 ```
 
+Minimal stack (UI + API + PDP only):
+```bash
+make dev-min
+```
+
+Default stack includes the observability profile:
+```bash
+make dev
+```
+This enables Redis + OTel Collector + Jaeger via `COMPOSE_PROFILES=obs`.
+
+Optional: include the Rust PEP gateway
+```bash
+make dev-rust
+```
+
+You can also opt in with profiles directly:
+```bash
+COMPOSE_PROFILES=rust-pep make dev
+```
+
 Optional: auto-seed the UI tenant
 Set `NEXT_PUBLIC_TENANT_ID` before starting the UI so the console auto-selects a tenant:
 ```bash

--- a/identity/control-plane/docs/receipts_integrity.md
+++ b/identity/control-plane/docs/receipts_integrity.md
@@ -31,3 +31,34 @@ ordered chain (oldest to newest). Failures are reported with:
 
 This is signing-ready: tables already include optional signature fields (`signature_alg`,
 `signature_kid`, `signature`, `signed_at`).
+
+## Known issue: HASH_MISMATCH from JSONB reordering
+
+When receipts are stored, the hash is computed from canonical JSON bytes produced by Go struct
+marshaling (field order is stable). During verification, the current implementation reads
+`body_json` back from Postgres as JSONB text and hashes those bytes. JSONB does not preserve key
+order, so the byte sequence can differ from the original canonical JSON even if the semantic
+content is identical. This can trigger `HASH_MISMATCH` even on a fresh database.
+
+Root cause:
+- Hashing uses canonical JSON bytes (Go struct field order).
+- Verification uses JSONB text (Postgres key order).
+- Different byte order → different hash.
+
+Implication:
+- `HASH_MISMATCH` may appear even without tampering when JSONB reorders keys.
+
+Mitigation:
+- Store the canonical JSON bytes used for hashing in `body_canonical` and verify against that column when present. This preserves the exact byte sequence used at hash time.
+
+Reset note:
+- The dev Postgres uses a bind mount at `identity/control-plane/deployments/local/.data/postgres`. To fully reset receipts for verification, stop the stack and delete that directory before reseeding.
+
+Example reset commands:
+```bash
+cd identity/control-plane
+docker compose -f deployments/docker-compose.yml down
+rm -rf deployments/local/.data/postgres
+make dev
+make seed
+```

--- a/identity/control-plane/docs/runbooks/security_demo.md
+++ b/identity/control-plane/docs/runbooks/security_demo.md
@@ -1,0 +1,139 @@
+# Security Demo Runbook
+
+Audience: security/platform stakeholders evaluating enforcement, controlled change, and auditability.
+
+Goal: show a denied tool call, a policy change that flips the outcome, and receipts that prove what happened.
+
+## Prerequisites
+- Docker Desktop running
+- `make` available
+- `curl` and `jq` installed
+
+## 0) Start stack + seed
+From `identity/control-plane/`:
+```bash
+make dev
+make seed
+```
+
+The seed output prints tenant IDs (e.g., TenantA/TenantB). Pick one and export it:
+```bash
+export TENANT_ID="<tenant-id-from-seed>"
+```
+
+Optional (UI auto-select tenant on first load):
+```bash
+export NEXT_PUBLIC_TENANT_ID="$TENANT_ID"
+```
+
+## 1) Verify system health
+```bash
+curl -s http://localhost:8080/healthz
+curl -s http://localhost:8081/healthz
+curl -s http://localhost:8082/healthz
+```
+
+Expected:
+- Each returns `ok` (HTTP 200).
+
+## 2) Baseline policy view (prove current state)
+```bash
+curl -s -H "x-umbra-tenant-id: $TENANT_ID" http://localhost:8080/v1/policies | jq .
+```
+
+Expected:
+- HTTP 200.
+- At least one policy visible (seeded policy is usually active).
+
+## 3) Demonstrate prevention (deny)
+Use the PEP to invoke an MCP-style tool call that is not allowed by policy.
+```bash
+curl -i -H "x-umbra-tenant-id: $TENANT_ID" http://localhost:8082/tool/secret
+```
+
+Expected:
+- HTTP `403 Forbidden` (enforce mode).
+- Response body includes a stable error message for denied enforcement.
+Note:
+- If `PEP_MODE=observe`, the request is forwarded and returns `200 OK`, but the receipt should indicate a deny decision.
+
+UI check:
+- Open http://localhost:3000 and navigate to Receipts.
+- You should see a new receipt for this blocked invocation.
+- Open the receipt detail and confirm `request_id` and `decision_id` are present.
+
+## 4) Controlled change (policy update)
+Flip policy outcome to allow the same tool call.
+
+Option A (UI):
+1) Navigate to Policies.
+2) Edit the active policy to allow `GET /secret` for the current role.
+3) Activate the updated policy.
+
+Option B (API, if you prefer scripted):
+- Create or update a policy to allow the path, then activate it via the policies endpoint.
+- Use existing policy tooling if available in the UI.
+
+Expected:
+- UI shows the new policy as active.
+- Active policy hash changes (note it for later).
+
+## 5) Demonstrate allow (same call now succeeds)
+```bash
+curl -i -H "x-umbra-tenant-id: $TENANT_ID" http://localhost:8082/tool/secret
+```
+
+Expected:
+- HTTP `200 OK`.
+- Body from upstream service (if configured).
+
+UI check:
+- Receipts show a new invocation receipt with `decision=allow`.
+- In receipt detail, confirm `policy_hash` matches the newly activated policy.
+
+## 6) Proof: receipts integrity verification
+```bash
+curl -s -X POST -H "x-umbra-tenant-id: $TENANT_ID" \
+  "http://localhost:8080/v1/receipts/verify?kind=all&limit=100" | jq .
+```
+
+Expected:
+- HTTP 200.
+- `status` (or equivalent) indicates PASS.
+- If it fails, the response includes the first failing receipt id/hash.
+Note:
+- In dev, `HASH_MISMATCH` usually means you are verifying receipts created by an older build or a previous DB state. If needed, reset the dev Postgres volume and reseed, then rerun the verify step. See `docs/receipts_integrity.md`.
+
+## 7) Proof: export receipts (JSON and CSV)
+Export receipts for audit review.
+```bash
+curl -s -H "x-umbra-tenant-id: $TENANT_ID" \
+  "http://localhost:8080/v1/receipts/export?format=json&limit=200" | jq .
+```
+
+Expected:
+- HTTP 200.
+- JSON array or JSONL with receipts including `request_id`, `decision_id`, and `policy_hash`.
+
+CSV export:
+```bash
+curl -s -H "x-umbra-tenant-id: $TENANT_ID" \
+  "http://localhost:8080/v1/receipts/export?format=csv&limit=200"
+```
+
+Expected:
+- HTTP 200.
+- CSV headers with receipt fields.
+
+## 8) Close the loop (what the audience should hear)
+- Enforcement happens **before** the tool call executes (deny prevents action).
+- Policy changes are controlled and auditable (active policy hash changes).
+- Receipts provide a tamper-evident trail with correlation IDs and policy hash.
+- Export and verification enable incident response and compliance review.
+
+## Troubleshooting
+- If you get `storage not configured`, restart services after Postgres is ready:
+  ```bash
+  docker compose -f deployments/docker-compose.yml restart controlplane-api pdp
+  ```
+- If UI requests fail, verify `x-umbra-tenant-id` is set (tenant switcher) and the API proxy is configured.

--- a/identity/control-plane/migrations/0006_add_receipt_canonical.sql
+++ b/identity/control-plane/migrations/0006_add_receipt_canonical.sql
@@ -1,0 +1,5 @@
+ALTER TABLE receipts_decision
+ADD COLUMN IF NOT EXISTS body_canonical bytea;
+
+ALTER TABLE receipts_invocation
+ADD COLUMN IF NOT EXISTS body_canonical bytea;

--- a/identity/control-plane/scripts/dev/seed_db.sh
+++ b/identity/control-plane/scripts/dev/seed_db.sh
@@ -24,6 +24,7 @@ $COMPOSE exec -T postgres psql -U umbra -d umbra -v ON_ERROR_STOP=1 -f /migratio
 $COMPOSE exec -T postgres psql -U umbra -d umbra -v ON_ERROR_STOP=1 -f /migrations/0003_add_receipt_indexes.sql
 $COMPOSE exec -T postgres psql -U umbra -d umbra -v ON_ERROR_STOP=1 -f /migrations/0004_add_receipt_search_indexes.sql
 $COMPOSE exec -T postgres psql -U umbra -d umbra -v ON_ERROR_STOP=1 -f /migrations/0005_add_receipt_search_text.sql
+$COMPOSE exec -T postgres psql -U umbra -d umbra -v ON_ERROR_STOP=1 -f /migrations/0006_add_receipt_canonical.sql
 
 echo "[seed] Seeding tenants..."
 TENANT_A=$($COMPOSE exec -T postgres psql -U umbra -d umbra -t -c "INSERT INTO tenants(name) VALUES('TenantA') ON CONFLICT(name) DO UPDATE SET name=EXCLUDED.name RETURNING id;" 2>&1 | grep -oE '[0-9a-f-]{36}' | head -1)

--- a/identity/control-plane/scripts/dev/wait_for_services.sh
+++ b/identity/control-plane/scripts/dev/wait_for_services.sh
@@ -38,7 +38,9 @@ wait_for_http() {
 wait_for_postgres
 wait_for_http "http://localhost:8080/healthz" "controlplane-api"
 wait_for_http "http://localhost:8081/healthz" "pdp"
-wait_for_http "http://localhost:8082/healthz" "pep-gateway"
+if [ "${SKIP_PEP_WAIT:-}" != "1" ]; then
+  wait_for_http "http://localhost:8082/healthz" "pep-gateway"
+fi
 
 # UI may take a bit more depending on build; check it but don't fail the overall startup if UI not ready yet
 if curl -sSf "http://localhost:3000" >/dev/null 2>&1; then
@@ -52,6 +54,10 @@ echo "\n[wait] Local endpoints:"
 echo "UI:  http://localhost:3000"
 echo "API: http://localhost:8080"
 echo "PDP: http://localhost:8081"
-echo "PEP: http://localhost:8082"
+if [ "${SKIP_PEP_WAIT:-}" != "1" ]; then
+  echo "PEP: http://localhost:8082"
+else
+  echo "PEP: not started (dev-min)"
+fi
 
 echo "[wait] Services appear to be ready"

--- a/identity/control-plane/services/README.md
+++ b/identity/control-plane/services/README.md
@@ -3,5 +3,6 @@
 - controlplane-api: policies/tools/audit query (admin plane)
 - pdp: decision evaluation endpoint
 - pep-gateway: enforcement proxy
+- pep-rust: Rust PEP for MCP tool-call enforcement
 - mcp-adapter: MCP tool-call enforcement adapter
 - mcp-upstream: demo MCP tool server for local stack

--- a/identity/control-plane/services/controlplane-api/internal/http-api/integration_test.go
+++ b/identity/control-plane/services/controlplane-api/internal/http-api/integration_test.go
@@ -121,9 +121,10 @@ func TestReceiptExportFiltersAndSafety(t *testing.T) {
 	decisionDenyID := uuid.New()
 
 	_, err = db.Pool.Exec(ctx, `
-    INSERT INTO receipts_decision(tenant_id, ts, decision_id, policy_hash, decision, body_json, prev_hash, hash, trace_id, span_id, request_id)
-    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+    INSERT INTO receipts_decision(tenant_id, ts, decision_id, policy_hash, decision, body_json, body_canonical, prev_hash, hash, trace_id, span_id, request_id)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
 		tenantID, tsAllow, decisionAllowID, "policy-hash-allow", "allow",
+		json.RawMessage(`{"actor":{"id":"user-1"},"tool":{"name":"tool.alpha"},"policy_version":1,"secret":"dont-export"}`),
 		json.RawMessage(`{"actor":{"id":"user-1"},"tool":{"name":"tool.alpha"},"policy_version":1,"secret":"dont-export"}`),
 		nil, "hash-allow", "trace-allow", "span-allow", "req-allow",
 	)
@@ -131,9 +132,10 @@ func TestReceiptExportFiltersAndSafety(t *testing.T) {
 		t.Fatalf("insert allow decision receipt failed: %v", err)
 	}
 	_, err = db.Pool.Exec(ctx, `
-    INSERT INTO receipts_decision(tenant_id, ts, decision_id, policy_hash, decision, body_json, prev_hash, hash, trace_id, span_id, request_id)
-    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+    INSERT INTO receipts_decision(tenant_id, ts, decision_id, policy_hash, decision, body_json, body_canonical, prev_hash, hash, trace_id, span_id, request_id)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
 		tenantID, tsDeny, decisionDenyID, "policy-hash-deny", "deny",
+		json.RawMessage(`{"actor":{"id":"user-2"},"tool":{"name":"tool.beta"},"policy_version":1,"secret":"dont-export"}`),
 		json.RawMessage(`{"actor":{"id":"user-2"},"tool":{"name":"tool.beta"},"policy_version":1,"secret":"dont-export"}`),
 		"prev-hash", "hash-deny", "trace-deny", "span-deny", "req-deny",
 	)
@@ -142,9 +144,10 @@ func TestReceiptExportFiltersAndSafety(t *testing.T) {
 	}
 
 	_, err = db.Pool.Exec(ctx, `
-    INSERT INTO receipts_invocation(tenant_id, ts, decision_id, tool_name, method, path, outcome, status_code, latency_ms, body_json, prev_hash, hash, trace_id, span_id, request_id)
-    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+    INSERT INTO receipts_invocation(tenant_id, ts, decision_id, tool_name, method, path, outcome, status_code, latency_ms, body_json, body_canonical, prev_hash, hash, trace_id, span_id, request_id)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
 		tenantID, tsAllow, decisionAllowID, "tool.alpha", "GET", "/demo", "error", 502, 42,
+		json.RawMessage(`{"policy_hash":"policy-hash-allow","policy_version":1,"secret":"dont-export"}`),
 		json.RawMessage(`{"policy_hash":"policy-hash-allow","policy_version":1,"secret":"dont-export"}`),
 		nil, "hash-inv", "trace-inv", "span-inv", "req-allow",
 	)

--- a/identity/control-plane/services/controlplane-api/internal/http-api/v0.go
+++ b/identity/control-plane/services/controlplane-api/internal/http-api/v0.go
@@ -875,16 +875,10 @@ func (s *Server) handleReceiptsExport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items, err := s.Store.ExportReceipts(ctx, tenant, filters)
-	if err != nil {
+	w.Header().Set("content-type", "application/json")
+	if err := s.Store.ExportReceiptsJSON(ctx, tenant, filters, w); err != nil {
 		http.Error(w, "db error", 500)
-		return
 	}
-
-	writeJSON(w, map[string]interface{}{
-		"schema_version": "v1",
-		"items":          items,
-	})
 }
 
 func (s *Server) handleReceiptsVerify(w http.ResponseWriter, r *http.Request) {

--- a/identity/control-plane/services/controlplane-api/internal/storage/storage.go
+++ b/identity/control-plane/services/controlplane-api/internal/storage/storage.go
@@ -591,12 +591,20 @@ func (s *Store) ExportReceiptsCSV(ctx context.Context, tenant uuid.UUID, f Expor
 	WriteReceiptsCSVHeader(writer)
 
 	if f.ActorID != "" {
-		decisions, err := s.exportDecisionReceipts(ctx, tenant, f)
+		rows, err := s.exportDecisionReceiptsRows(ctx, tenant, f)
 		if err != nil {
 			return err
 		}
-		for _, record := range decisions {
+		defer rows.Close()
+		for rows.Next() {
+			record, err := scanDecisionExportRow(rows)
+			if err != nil {
+				return err
+			}
 			WriteReceiptsCSVRecord(writer, record)
+		}
+		if err := rows.Err(); err != nil {
+			return err
 		}
 		writer.Flush()
 		return writer.Error()
@@ -622,6 +630,33 @@ func (s *Store) ExportReceiptsCSV(ctx context.Context, tenant uuid.UUID, f Expor
 	return writer.Error()
 }
 
+func (s *Store) ExportReceiptsJSON(ctx context.Context, tenant uuid.UUID, f ExportFilters, w io.Writer) error {
+	if f.Limit <= 0 || f.Limit > 500 {
+		f.Limit = 100
+	}
+	f.ActorID = strings.TrimSpace(f.ActorID)
+	f.Tool = strings.TrimSpace(f.Tool)
+	f.Decision = strings.ToLower(strings.TrimSpace(f.Decision))
+	f.RequestID = strings.TrimSpace(f.RequestID)
+	f.DecisionID = strings.TrimSpace(f.DecisionID)
+
+	if f.ActorID != "" {
+		rows, err := s.exportDecisionReceiptsRows(ctx, tenant, f)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		return writeReceiptsJSONStream(rows, scanDecisionExportRow, w)
+	}
+
+	rows, err := s.exportReceiptsUnionRows(ctx, tenant, f)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	return writeReceiptsJSONStream(rows, scanExportUnionRow, w)
+}
+
 func (s *Store) ExportReceipts(ctx context.Context, tenant uuid.UUID, f ExportFilters) ([]ExportRecord, error) {
 	if f.Limit <= 0 || f.Limit > 500 {
 		f.Limit = 100
@@ -641,6 +676,59 @@ func (s *Store) ExportReceipts(ctx context.Context, tenant uuid.UUID, f ExportFi
 	}
 
 	return s.exportReceiptsUnion(ctx, tenant, f)
+}
+
+func (s *Store) exportDecisionReceiptsRows(ctx context.Context, tenant uuid.UUID, f ExportFilters) (pgx.Rows, error) {
+	args := []interface{}{tenant}
+	idx := 2
+	where := " WHERE tenant_id=$1 "
+	if f.From != nil {
+		where += " AND ts >= $" + itoa(idx)
+		args = append(args, *f.From)
+		idx++
+	}
+	if f.To != nil {
+		where += " AND ts <= $" + itoa(idx)
+		args = append(args, *f.To)
+		idx++
+	}
+	if f.ActorID != "" {
+		where += " AND body_json->'actor'->>'id' = $" + itoa(idx)
+		args = append(args, f.ActorID)
+		idx++
+	}
+	if f.Tool != "" {
+		where += " AND body_json->'tool'->>'name' = $" + itoa(idx)
+		args = append(args, f.Tool)
+		idx++
+	}
+	if f.Decision != "" {
+		where += " AND decision = $" + itoa(idx)
+		args = append(args, f.Decision)
+		idx++
+	}
+	if f.RequestID != "" {
+		where += " AND request_id = $" + itoa(idx)
+		args = append(args, f.RequestID)
+		idx++
+	}
+	if f.DecisionID != "" {
+		where += " AND decision_id = $" + itoa(idx)
+		args = append(args, f.DecisionID)
+		idx++
+	}
+
+	args = append(args, f.Limit)
+	sql := `
+    SELECT ts, decision_id, request_id, trace_id, policy_hash, decision, hash, prev_hash,
+      body_json->'actor'->>'id' AS actor_id,
+      body_json->'tool'->>'name' AS tool_name,
+      NULLIF(body_json->>'policy_version','')::int AS policy_version
+    FROM receipts_decision` + where + `
+    ORDER BY ts DESC
+    LIMIT $` + itoa(idx)
+
+	return s.db.Query(ctx, sql, args...)
 }
 
 func (s *Store) exportDecisionReceipts(ctx context.Context, tenant uuid.UUID, f ExportFilters) ([]ExportRecord, error) {
@@ -701,33 +789,9 @@ func (s *Store) exportDecisionReceipts(ctx context.Context, tenant uuid.UUID, f 
 
 	out := []ExportRecord{}
 	for rows.Next() {
-		var ts time.Time
-		var decisionID, requestID, traceID, policyHash, decision string
-		var hash string
-		var prev *string
-		var actorID, toolName *string
-		var policyVersion *int
-		if err := rows.Scan(&ts, &decisionID, &requestID, &traceID, &policyHash, &decision, &hash, &prev, &actorID, &toolName, &policyVersion); err != nil {
+		record, err := scanDecisionExportRow(rows)
+		if err != nil {
 			return nil, err
-		}
-		record := ExportRecord{
-			SchemaVersion:   "v1",
-			Kind:            "decision",
-			TS:              ts,
-			RequestID:       requestID,
-			DecisionID:      decisionID,
-			TraceID:         traceID,
-			PolicyHash:      policyHash,
-			PolicyVersion:   policyVersion,
-			Decision:        decision,
-			ReceiptHash:     hash,
-			ReceiptPrevHash: derefString(prev),
-		}
-		if actorID != nil {
-			record.ActorID = *actorID
-		}
-		if toolName != nil {
-			record.ToolName = *toolName
 		}
 		out = append(out, record)
 	}
@@ -995,6 +1059,69 @@ func scanExportUnionRow(rows pgx.Rows) (ExportRecord, error) {
 	record.StatusCode = statusCode
 
 	return record, nil
+}
+
+func scanDecisionExportRow(rows pgx.Rows) (ExportRecord, error) {
+	var ts time.Time
+	var decisionID, requestID, traceID, policyHash, decision string
+	var hash string
+	var prev *string
+	var actorID, toolName *string
+	var policyVersion *int
+	if err := rows.Scan(&ts, &decisionID, &requestID, &traceID, &policyHash, &decision, &hash, &prev, &actorID, &toolName, &policyVersion); err != nil {
+		return ExportRecord{}, err
+	}
+	record := ExportRecord{
+		SchemaVersion:   "v1",
+		Kind:            "decision",
+		TS:              ts,
+		RequestID:       requestID,
+		DecisionID:      decisionID,
+		TraceID:         traceID,
+		PolicyHash:      policyHash,
+		PolicyVersion:   policyVersion,
+		Decision:        decision,
+		ReceiptHash:     hash,
+		ReceiptPrevHash: derefString(prev),
+	}
+	if actorID != nil {
+		record.ActorID = *actorID
+	}
+	if toolName != nil {
+		record.ToolName = *toolName
+	}
+	return record, nil
+}
+
+func writeReceiptsJSONStream(rows pgx.Rows, scan func(pgx.Rows) (ExportRecord, error), w io.Writer) error {
+	if _, err := io.WriteString(w, `{"schema_version":"v1","items":[`); err != nil {
+		return err
+	}
+	first := true
+	for rows.Next() {
+		record, err := scan(rows)
+		if err != nil {
+			return err
+		}
+		data, err := json.Marshal(record)
+		if err != nil {
+			return err
+		}
+		if !first {
+			if _, err := io.WriteString(w, ","); err != nil {
+				return err
+			}
+		}
+		first = false
+		if _, err := w.Write(data); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w, "]}")
+	return err
 }
 
 func buildDecisionWhere(tenant uuid.UUID, start int, f ExportFilters) (string, []interface{}, int) {

--- a/identity/control-plane/services/controlplane-api/internal/storage/storage.go
+++ b/identity/control-plane/services/controlplane-api/internal/storage/storage.go
@@ -253,10 +253,10 @@ func (s *Store) InsertDecisionReceipt(ctx context.Context,
 ) (uuid.UUID, error) {
 	var id uuid.UUID
 	err := s.db.QueryRow(ctx, `
-    INSERT INTO receipts_decision(tenant_id, decision_id, request_id, policy_hash, decision, body_json, prev_hash, hash, trace_id, span_id)
-    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+    INSERT INTO receipts_decision(tenant_id, decision_id, request_id, policy_hash, decision, body_json, body_canonical, prev_hash, hash, trace_id, span_id)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
     RETURNING id`,
-		tenant, decisionID, nullIfEmpty(requestID), policyHash, decision, body, nullIfEmpty(prevHash), hash, nullIfEmpty(traceID), nullIfEmpty(spanID)).
+		tenant, decisionID, nullIfEmpty(requestID), policyHash, decision, body, body, nullIfEmpty(prevHash), hash, nullIfEmpty(traceID), nullIfEmpty(spanID)).
 		Scan(&id)
 	return id, err
 }
@@ -279,8 +279,8 @@ func (s *Store) InsertInvocationReceipt(ctx context.Context,
 ) (uuid.UUID, error) {
 	var id uuid.UUID
 	err := s.db.QueryRow(ctx, `
-    INSERT INTO receipts_invocation(tenant_id, decision_id, request_id, tool_name, method, path, outcome, status_code, latency_ms, body_json, prev_hash, hash, trace_id, span_id)
-    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+    INSERT INTO receipts_invocation(tenant_id, decision_id, request_id, tool_name, method, path, outcome, status_code, latency_ms, body_json, body_canonical, prev_hash, hash, trace_id, span_id)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
     RETURNING id`,
 		tenant,
 		decisionID,
@@ -291,6 +291,7 @@ func (s *Store) InsertInvocationReceipt(ctx context.Context,
 		outcome,
 		statusCode,
 		latencyMs,
+		body,
 		body,
 		nullIfEmpty(prevHash),
 		hash,
@@ -1095,7 +1096,7 @@ func derefString(v *string) string {
 
 func (s *Store) listReceiptChain(ctx context.Context, tenant uuid.UUID, limit int, table string) ([]receipts.ChainRecord, error) {
 	rows, err := s.db.Query(ctx, `
-    SELECT id, body_json, prev_hash, hash, ts
+    SELECT id, COALESCE(body_canonical, convert_to(body_json::text, 'utf8')) AS body, prev_hash, hash, ts
     FROM `+table+`
     WHERE tenant_id=$1
     ORDER BY ts DESC

--- a/identity/control-plane/services/mcp-adapter/internal/storage/storage.go
+++ b/identity/control-plane/services/mcp-adapter/internal/storage/storage.go
@@ -47,8 +47,8 @@ func (s *Store) InsertInvocationReceipt(ctx context.Context,
 	spanID string,
 ) error {
 	_, err := s.db.Exec(ctx, `
-    INSERT INTO receipts_invocation(tenant_id, decision_id, request_id, tool_name, method, path, outcome, status_code, latency_ms, body_json, prev_hash, hash, trace_id, span_id)
-    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+    INSERT INTO receipts_invocation(tenant_id, decision_id, request_id, tool_name, method, path, outcome, status_code, latency_ms, body_json, body_canonical, prev_hash, hash, trace_id, span_id)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
 		tenant,
 		decisionID,
 		nullIfEmpty(requestID),
@@ -58,6 +58,7 @@ func (s *Store) InsertInvocationReceipt(ctx context.Context,
 		outcome,
 		statusCode,
 		latencyMs,
+		body,
 		body,
 		nullIfEmpty(prevHash),
 		hash,

--- a/identity/control-plane/services/pdp/internal/storage/storage.go
+++ b/identity/control-plane/services/pdp/internal/storage/storage.go
@@ -65,9 +65,9 @@ func (s *Store) InsertDecisionReceipt(ctx context.Context,
 	spanID string,
 ) error {
 	_, err := s.db.Exec(ctx, `
-    INSERT INTO receipts_decision(tenant_id, decision_id, request_id, policy_hash, decision, body_json, prev_hash, hash, trace_id, span_id)
-    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
-		tenant, decisionID, nullIfEmpty(requestID), policyHash, decision, body, nullIfEmpty(prevHash), hash, nullIfEmpty(traceID), nullIfEmpty(spanID))
+    INSERT INTO receipts_decision(tenant_id, decision_id, request_id, policy_hash, decision, body_json, body_canonical, prev_hash, hash, trace_id, span_id)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+		tenant, decisionID, nullIfEmpty(requestID), policyHash, decision, body, body, nullIfEmpty(prevHash), hash, nullIfEmpty(traceID), nullIfEmpty(spanID))
 	return err
 }
 

--- a/identity/control-plane/services/pep-gateway/internal/storage/storage.go
+++ b/identity/control-plane/services/pep-gateway/internal/storage/storage.go
@@ -52,8 +52,8 @@ func (s *Store) InsertInvocationReceipt(ctx context.Context,
 	spanID string,
 ) error {
 	_, err := s.db.Exec(ctx, `
-    INSERT INTO receipts_invocation(tenant_id, decision_id, request_id, tool_name, method, path, outcome, status_code, latency_ms, body_json, prev_hash, hash, trace_id, span_id)
-    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+    INSERT INTO receipts_invocation(tenant_id, decision_id, request_id, tool_name, method, path, outcome, status_code, latency_ms, body_json, body_canonical, prev_hash, hash, trace_id, span_id)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
 		tenant,
 		decisionID,
 		nullIfEmpty(requestID),
@@ -63,6 +63,7 @@ func (s *Store) InsertInvocationReceipt(ctx context.Context,
 		outcome,
 		statusCode,
 		latencyMs,
+		body,
 		body,
 		nullIfEmpty(prevHash),
 		hash,

--- a/identity/control-plane/services/pep-rust/Cargo.toml
+++ b/identity/control-plane/services/pep-rust/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "pep-rust"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = "0.7.5"
+bytes = "1.7.1"
+chrono = { version = "0.4.38", default-features = false, features = ["std", "clock"] }
+reqwest = { version = "0.12.7", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1.0.208", features = ["derive"] }
+serde_json = "1.0.125"
+tokio = { version = "1.39.2", features = ["macros", "rt-multi-thread"] }
+tower = { version = "0.4.13", features = ["limit"] }
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+uuid = { version = "1.10.0", features = ["v4", "serde"] }
+
+[dev-dependencies]
+http-body-util = "0.1.2"

--- a/identity/control-plane/services/pep-rust/Dockerfile
+++ b/identity/control-plane/services/pep-rust/Dockerfile
@@ -1,0 +1,11 @@
+FROM rust:1.83-bookworm AS build
+WORKDIR /src
+COPY services/pep-rust/Cargo.toml ./Cargo.toml
+COPY services/pep-rust/src ./src
+RUN cargo build --release
+
+FROM gcr.io/distroless/cc-debian12:nonroot
+COPY --from=build /src/target/release/pep-rust /pep-rust
+USER nonroot
+EXPOSE 8084
+ENTRYPOINT ["/pep-rust"]

--- a/identity/control-plane/services/pep-rust/README.md
+++ b/identity/control-plane/services/pep-rust/README.md
@@ -1,0 +1,21 @@
+# Rust PEP (pep-rust)
+
+MCP-first enforcement service that delegates decisions to PDP and writes receipts via controlplane-api.
+
+## Env vars
+
+- `PEP_MODE`: `observe` or `enforce` (default: `observe`)
+- `PDP_URL`: PDP base URL (default: `http://pdp:8081`)
+- `CONTROLPLANE_API_URL`: Control plane API base URL (default: `http://controlplane-api:8080`)
+- `MCP_UPSTREAM_URL`: MCP upstream URL (required for forwarding)
+- `MCP_TENANT_ID`: tenant UUID for requests (default: `00000000-0000-0000-0000-000000000001`)
+- `MCP_ACTOR_ID`: actor id (default: `user-1`)
+- `MCP_ACTOR_TYPE`: actor type (default: `agent`)
+- `MCP_ACTOR_ROLES`: CSV roles (default: `developer`)
+- `MCP_SERVER_NAME`: MCP server name (default: `demo.mcp`)
+- `PORT`: listen port (default: `8084`)
+
+## Endpoints
+
+- `POST /mcp` JSON-RPC MCP tool calls (`tools/call`)
+- `GET /healthz` service health

--- a/identity/control-plane/services/pep-rust/src/main.rs
+++ b/identity/control-plane/services/pep-rust/src/main.rs
@@ -1,0 +1,997 @@
+use axum::{
+    extract::{DefaultBodyLimit, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::{
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
+use tokio::net::TcpListener;
+use tower::limit::ConcurrencyLimitLayer;
+use tower::ServiceBuilder;
+use tracing::{error, info};
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct AppState {
+    cfg: Config,
+    pdp_client: Client,
+    upstream_client: Client,
+    controlplane_client: Client,
+}
+
+#[derive(Clone)]
+struct Config {
+    pep_mode: PepMode,
+    pdp_url: String,
+    controlplane_url: String,
+    upstream_url: String,
+    tenant_id: String,
+    actor_id: String,
+    actor_type: String,
+    actor_roles: Vec<String>,
+    server_name: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PepMode {
+    Enforce,
+    Observe,
+}
+
+impl PepMode {
+    fn from_env() -> Self {
+        match std::env::var("PEP_MODE")
+            .unwrap_or_else(|_| "observe".to_string())
+            .to_lowercase()
+            .as_str()
+        {
+            "enforce" => PepMode::Enforce,
+            _ => PepMode::Observe,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct RpcRequest {
+    jsonrpc: String,
+    id: Option<Value>,
+    method: String,
+    params: Option<Value>,
+}
+
+#[derive(Serialize)]
+struct RpcResponse {
+    jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<RpcError>,
+}
+
+#[derive(Serialize)]
+struct RpcError {
+    code: i32,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ToolCallParams {
+    name: String,
+    #[serde(default)]
+    server: Option<String>,
+    #[serde(default)]
+    request_id: Option<String>,
+    #[serde(default)]
+    workspace: Option<String>,
+    #[serde(default)]
+    args_schema_version: Option<String>,
+    #[serde(default)]
+    actor: Option<ActorParams>,
+    #[serde(default)]
+    arguments: Option<Value>,
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+struct ActorParams {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    r#type: Option<String>,
+    #[serde(default)]
+    roles: Option<Vec<String>>,
+    #[serde(default)]
+    source: Option<String>,
+}
+
+#[derive(Serialize)]
+struct DecisionRequest {
+    tenant: TenantContext,
+    actor: Actor,
+    tool: Tool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mcp: Option<McpContext>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trace: Option<TraceContext>,
+}
+
+#[derive(Serialize)]
+struct TenantContext {
+    tenant_id: String,
+}
+
+#[derive(Serialize)]
+struct Actor {
+    r#type: String,
+    id: String,
+    roles: Vec<String>,
+    source: String,
+}
+
+#[derive(Serialize)]
+struct Tool {
+    name: String,
+    method: String,
+    endpoint: String,
+}
+
+#[derive(Serialize)]
+struct McpContext {
+    server: String,
+    tool: String,
+    method: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace: Option<String>,
+}
+
+#[derive(Serialize)]
+struct TraceContext {
+    request_id: String,
+}
+
+#[derive(Deserialize)]
+struct DecisionResponse {
+    decision: String,
+    decision_id: String,
+    #[serde(default)]
+    policy_hash: String,
+    #[serde(default)]
+    policy_version: i32,
+    #[serde(default)]
+    reason: String,
+}
+
+#[derive(Serialize)]
+struct ReceiptIngestRequest {
+    kind: &'static str,
+    request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    decision_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    decision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    policy_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    policy_version: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    outcome: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    latency_ms: Option<i32>,
+    body: Value,
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .init();
+
+    let cfg = Config {
+        pep_mode: PepMode::from_env(),
+        pdp_url: env("PDP_URL", "http://pdp:8081"),
+        controlplane_url: env("CONTROLPLANE_API_URL", "http://controlplane-api:8080"),
+        upstream_url: env("MCP_UPSTREAM_URL", ""),
+        tenant_id: env("MCP_TENANT_ID", "00000000-0000-0000-0000-000000000001"),
+        actor_id: env("MCP_ACTOR_ID", "user-1"),
+        actor_type: env("MCP_ACTOR_TYPE", "agent"),
+        actor_roles: parse_csv(&env("MCP_ACTOR_ROLES", "developer")),
+        server_name: env("MCP_SERVER_NAME", "demo.mcp"),
+    };
+
+    let pdp_timeout = duration_ms("PDP_TIMEOUT_MS", 3000);
+    let tool_timeout = duration_ms("TOOL_TIMEOUT_MS", 5000);
+    let receipt_timeout = duration_ms("RECEIPT_TIMEOUT_MS", 3000);
+
+    let state = AppState {
+        cfg,
+        pdp_client: Client::builder().timeout(pdp_timeout).build().unwrap(),
+        upstream_client: Client::builder().timeout(tool_timeout).build().unwrap(),
+        controlplane_client: Client::builder()
+            .timeout(receipt_timeout)
+            .build()
+            .unwrap(),
+    };
+
+    let app = Router::new()
+        .route("/healthz", get(healthz))
+        .route("/mcp", post(handle_mcp))
+        .layer(DefaultBodyLimit::max(1 << 20))
+        .layer(ServiceBuilder::new().layer(ConcurrencyLimitLayer::new(100)))
+        .with_state(state);
+
+    let addr: SocketAddr = format!("0.0.0.0:{}", env("PORT", "8084"))
+        .parse()
+        .expect("valid addr");
+    info!("starting pep-rust on {}", addr);
+    let listener = TcpListener::bind(addr).await.expect("bind");
+    axum::serve(listener, app).await.expect("server failed");
+}
+
+async fn healthz() -> impl IntoResponse {
+    Json(json!({
+        "ok": true,
+        "service": "pep-rust",
+        "time": chrono::Utc::now().to_rfc3339(),
+    }))
+}
+
+async fn handle_mcp(State(state): State<AppState>, body: bytes::Bytes) -> Response {
+    let req: RpcRequest = match serde_json::from_slice(&body) {
+        Ok(req) => req,
+        Err(_) => {
+            return rpc_error(
+                StatusCode::BAD_REQUEST,
+                None,
+                "invalid json",
+                "BAD_REQUEST",
+                "",
+                None,
+            )
+        }
+    };
+
+    if req.method.trim() != "tools/call" {
+        return rpc_error(
+            StatusCode::BAD_REQUEST,
+            req.id,
+            "method not supported",
+            "METHOD_NOT_SUPPORTED",
+            "",
+            None,
+        );
+    }
+
+    let params: ToolCallParams = match req
+        .params
+        .clone()
+        .and_then(|v| serde_json::from_value(v).ok())
+    {
+        Some(p) => p,
+        None => {
+            return rpc_error(
+                StatusCode::BAD_REQUEST,
+                req.id,
+                "invalid params",
+                "BAD_PARAMS",
+                "",
+                None,
+            )
+        }
+    };
+
+    let request_id = params
+        .request_id
+        .clone()
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    let started = Instant::now();
+
+    let actor = resolve_actor(&state.cfg, &params.actor);
+    let tool_name = params.name.trim().to_string();
+    if tool_name.is_empty() {
+        return rpc_error(
+            StatusCode::BAD_REQUEST,
+            req.id,
+            "missing tool name",
+            "BAD_PARAMS",
+            &request_id,
+            None,
+        );
+    }
+
+    let server_name = params
+        .server
+        .clone()
+        .unwrap_or_else(|| state.cfg.server_name.clone());
+    let mcp_method = req.method.to_lowercase();
+    let endpoint = format!("{}/{}", server_name, tool_name);
+
+    let decision_req = DecisionRequest {
+        tenant: TenantContext {
+            tenant_id: state.cfg.tenant_id.clone(),
+        },
+        actor: Actor {
+            r#type: actor.r#type.clone(),
+            id: actor.id.clone(),
+            roles: actor.roles.clone(),
+            source: actor.source.clone(),
+        },
+        tool: Tool {
+            name: tool_name.clone(),
+            method: mcp_method.clone(),
+            endpoint: endpoint.clone(),
+        },
+        mcp: Some(McpContext {
+            server: server_name.clone(),
+            tool: tool_name.clone(),
+            method: mcp_method.clone(),
+            workspace: params.workspace.clone(),
+        }),
+        trace: Some(TraceContext {
+            request_id: request_id.clone(),
+        }),
+    };
+
+    let pdp_started = Instant::now();
+    let mut pdp_status = "ok".to_string();
+    let mut decision: Option<DecisionResponse> = None;
+
+    let pdp_url = format!("{}/v1/decision", state.cfg.pdp_url.trim_end_matches('/'));
+    match state.pdp_client.post(pdp_url).json(&decision_req).send().await {
+        Ok(resp) => match resp.json::<DecisionResponse>().await {
+            Ok(dec) => decision = Some(dec),
+            Err(_err) => {
+                pdp_status = "unavailable".to_string();
+            }
+        },
+        Err(_err) => {
+            pdp_status = "unavailable".to_string();
+        }
+    }
+
+    let pdp_latency_ms = pdp_started.elapsed().as_millis() as i32;
+    let mut forward = false;
+    let mut enforcement = "blocked";
+    let mut outcome = "denied";
+    let mut status = StatusCode::FORBIDDEN;
+    let mut decision_id = None;
+    let mut policy_hash = None;
+    let mut policy_version = None;
+
+    if let Some(dec) = &decision {
+        decision_id = Some(dec.decision_id.clone());
+        if !dec.policy_hash.is_empty() {
+            policy_hash = Some(dec.policy_hash.clone());
+        }
+        if dec.policy_version > 0 {
+            policy_version = Some(dec.policy_version);
+        }
+        if dec.decision.to_lowercase() == "allow" {
+            forward = true;
+            enforcement = "forwarded";
+            outcome = "success";
+            status = StatusCode::OK;
+        } else if state.cfg.pep_mode == PepMode::Observe {
+            forward = true;
+            enforcement = "forwarded";
+            outcome = "denied";
+            status = StatusCode::OK;
+        }
+    } else if state.cfg.pep_mode == PepMode::Observe {
+        forward = true;
+        enforcement = "forwarded";
+        outcome = "success";
+        status = StatusCode::OK;
+    } else {
+        status = StatusCode::SERVICE_UNAVAILABLE;
+    }
+
+    if forward {
+        let mut params_obj = serde_json::to_value(&params).unwrap_or_else(|_| json!({}));
+        if let Value::Object(ref mut map) = params_obj {
+            map.insert("request_id".to_string(), Value::String(request_id.clone()));
+        }
+        let forward_body = json!({
+            "jsonrpc": req.jsonrpc,
+            "id": req.id,
+            "method": req.method,
+            "params": params_obj,
+        });
+
+        let upstream_url = state.cfg.upstream_url.clone();
+        if upstream_url.is_empty() {
+            write_receipt(
+                &state,
+                &request_id,
+                &tool_name,
+                &mcp_method,
+                &outcome,
+                Some(status.as_u16() as i32),
+                &decision_id,
+                &policy_hash,
+                policy_version,
+                &actor,
+                &server_name,
+                params.workspace.clone(),
+                enforcement,
+                &pdp_status,
+                decision.as_ref().map(|d| d.decision.as_str()),
+                pdp_latency_ms,
+                0,
+                started.elapsed().as_millis() as i32,
+            )
+            .await;
+            return rpc_error(
+                StatusCode::BAD_GATEWAY,
+                req.id,
+                "upstream unavailable",
+                "UPSTREAM_UNAVAILABLE",
+                &request_id,
+                decision_id.clone(),
+            );
+        }
+
+        let tool_started = Instant::now();
+        let upstream_resp = state
+            .upstream_client
+            .post(upstream_url)
+            .header("content-type", "application/json")
+            .json(&forward_body)
+            .send()
+            .await;
+
+        match upstream_resp {
+            Ok(resp) => {
+                let status_code = resp.status();
+                let body = resp.json::<Value>().await.unwrap_or_else(|_| json!({}));
+                let mut final_outcome = outcome;
+                if final_outcome == "success" && status_code.as_u16() >= 400 {
+                    final_outcome = "error";
+                }
+                let tool_latency_ms = tool_started.elapsed().as_millis() as i32;
+                let total_latency_ms = started.elapsed().as_millis() as i32;
+                write_receipt(
+                    &state,
+                    &request_id,
+                    &tool_name,
+                    &mcp_method,
+                    &final_outcome,
+                    Some(status_code.as_u16() as i32),
+                    &decision_id,
+                    &policy_hash,
+                    policy_version,
+                    &actor,
+                    &server_name,
+                    params.workspace.clone(),
+                    enforcement,
+                    &pdp_status,
+                    decision.as_ref().map(|d| d.decision.as_str()),
+                    pdp_latency_ms,
+                    tool_latency_ms,
+                    total_latency_ms,
+                )
+                .await;
+                return (status_code, Json(body)).into_response();
+            }
+            Err(err) => {
+                error!("upstream error: {}", err);
+                let tool_latency_ms = tool_started.elapsed().as_millis() as i32;
+                let total_latency_ms = started.elapsed().as_millis() as i32;
+                write_receipt(
+                    &state,
+                    &request_id,
+                    &tool_name,
+                    &mcp_method,
+                    "error",
+                    Some(StatusCode::BAD_GATEWAY.as_u16() as i32),
+                    &decision_id,
+                    &policy_hash,
+                    policy_version,
+                    &actor,
+                    &server_name,
+                    params.workspace.clone(),
+                    enforcement,
+                    &pdp_status,
+                    decision.as_ref().map(|d| d.decision.as_str()),
+                    pdp_latency_ms,
+                    tool_latency_ms,
+                    total_latency_ms,
+                )
+                .await;
+                return rpc_error(
+                    StatusCode::BAD_GATEWAY,
+                    req.id,
+                    "upstream error",
+                    "UPSTREAM_ERROR",
+                    &request_id,
+                    decision_id.clone(),
+                );
+            }
+        }
+    }
+
+    let total_latency_ms = started.elapsed().as_millis() as i32;
+    write_receipt(
+        &state,
+        &request_id,
+        &tool_name,
+        &mcp_method,
+        &outcome,
+        Some(status.as_u16() as i32),
+        &decision_id,
+        &policy_hash,
+        policy_version,
+        &actor,
+        &server_name,
+        params.workspace.clone(),
+        enforcement,
+        &pdp_status,
+        decision.as_ref().map(|d| d.decision.as_str()),
+        pdp_latency_ms,
+        0,
+        total_latency_ms,
+    )
+    .await;
+
+    if decision.is_none() {
+        return rpc_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            req.id,
+            "policy unavailable",
+            "POLICY_UNAVAILABLE",
+            &request_id,
+            None,
+        );
+    }
+
+    rpc_error(
+        StatusCode::FORBIDDEN,
+        req.id,
+        "policy denied",
+        "POLICY_DENIED",
+        &request_id,
+        decision_id.clone(),
+    )
+}
+
+async fn write_receipt(
+    state: &AppState,
+    request_id: &str,
+    tool_name: &str,
+    method: &str,
+    outcome: &str,
+    status_code: Option<i32>,
+    decision_id: &Option<String>,
+    policy_hash: &Option<String>,
+    policy_version: Option<i32>,
+    actor: &ActorIdentity,
+    server_name: &str,
+    workspace: Option<String>,
+    enforcement: &str,
+    pdp_status: &str,
+    decision_result: Option<&str>,
+    pdp_latency_ms: i32,
+    tool_latency_ms: i32,
+    total_latency_ms: i32,
+) {
+    let body = json!({
+        "actor": {
+            "id": actor.id,
+            "type": actor.r#type,
+            "roles": actor.roles,
+            "source": actor.source,
+        },
+        "mcp": {
+            "server": server_name,
+            "tool": tool_name,
+            "method": method,
+            "workspace": workspace,
+        },
+        "decision": decision_result,
+        "outcome": outcome,
+        "enforcement": enforcement,
+        "pep_mode": match state.cfg.pep_mode { PepMode::Enforce => "enforce", PepMode::Observe => "observe" },
+        "pdp_status": pdp_status,
+        "pdp_latency_ms": pdp_latency_ms,
+        "tool_latency_ms": tool_latency_ms,
+        "total_latency_ms": total_latency_ms,
+        "policy_hash": policy_hash,
+        "policy_version": policy_version,
+        "request_id": request_id,
+    });
+
+    let payload = ReceiptIngestRequest {
+        kind: "invocation",
+        request_id: request_id.to_string(),
+        decision_id: decision_id.clone(),
+        decision: None,
+        policy_hash: policy_hash.clone(),
+        policy_version,
+        tool_name: Some(tool_identifier(server_name, tool_name)),
+        method: Some(method.to_string()),
+        path: Some(tool_name.to_string()),
+        outcome: Some(outcome.to_string()),
+        status_code,
+        latency_ms: Some(total_latency_ms),
+        body,
+    };
+
+    let url = format!(
+        "{}/v1/receipts",
+        state.cfg.controlplane_url.trim_end_matches('/')
+    );
+    let resp = state
+        .controlplane_client
+        .post(url)
+        .header("x-umbra-tenant-id", &state.cfg.tenant_id)
+        .json(&payload)
+        .send()
+        .await;
+
+    if let Err(err) = resp {
+        error!("receipt ingest failed: {}", err);
+    }
+}
+
+fn resolve_actor(cfg: &Config, params: &Option<ActorParams>) -> ActorIdentity {
+    if let Some(p) = params {
+        return ActorIdentity {
+            id: p.id.clone().unwrap_or_else(|| cfg.actor_id.clone()),
+            r#type: p.r#type.clone().unwrap_or_else(|| cfg.actor_type.clone()),
+            roles: p.roles.clone().unwrap_or_else(|| cfg.actor_roles.clone()),
+            source: p
+                .source
+                .clone()
+                .unwrap_or_else(|| "params".to_string()),
+        };
+    }
+    ActorIdentity {
+        id: cfg.actor_id.clone(),
+        r#type: cfg.actor_type.clone(),
+        roles: cfg.actor_roles.clone(),
+        source: "env".to_string(),
+    }
+}
+
+#[derive(Clone)]
+struct ActorIdentity {
+    id: String,
+    r#type: String,
+    roles: Vec<String>,
+    source: String,
+}
+
+fn rpc_error(
+    status: StatusCode,
+    id: Option<Value>,
+    msg: &str,
+    code: &str,
+    request_id: &str,
+    decision_id: Option<String>,
+) -> Response {
+    let mut data = serde_json::Map::new();
+    data.insert("error_code".to_string(), Value::String(code.to_string()));
+    if !request_id.is_empty() {
+        data.insert("request_id".to_string(), Value::String(request_id.to_string()));
+    }
+    if let Some(decision_id) = decision_id {
+        data.insert("decision_id".to_string(), Value::String(decision_id));
+    }
+    let resp = RpcResponse {
+        jsonrpc: "2.0",
+        id,
+        result: None,
+        error: Some(RpcError {
+            code: -32000,
+            message: msg.to_string(),
+            data: Some(Value::Object(data)),
+        }),
+    };
+    (status, Json(resp)).into_response()
+}
+
+fn tool_identifier(server: &str, tool: &str) -> String {
+    if server.is_empty() {
+        return tool.to_string();
+    }
+    format!("{}:{}", server, tool)
+}
+
+fn env(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+fn duration_ms(key: &str, default_ms: u64) -> Duration {
+    let val = std::env::var(key).ok().and_then(|v| v.parse::<u64>().ok());
+    Duration::from_millis(val.unwrap_or(default_ms))
+}
+
+fn parse_csv(s: &str) -> Vec<String> {
+    s.split(',')
+        .map(|v| v.trim())
+        .filter(|v| !v.is_empty())
+        .map(|v| v.to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request, routing::post, Router};
+    use http_body_util::BodyExt;
+    use std::sync::{Arc, Mutex};
+    use tokio::net::TcpListener;
+    use tower::ServiceExt;
+
+    async fn start_server(app: Router) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{}", addr)
+    }
+
+    fn test_state(
+        pep_mode: PepMode,
+        pdp_url: String,
+        controlplane_url: String,
+        upstream_url: String,
+    ) -> AppState {
+        AppState {
+            cfg: Config {
+                pep_mode,
+                pdp_url,
+                controlplane_url,
+                upstream_url,
+                tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
+                actor_id: "user-1".to_string(),
+                actor_type: "agent".to_string(),
+                actor_roles: vec!["developer".to_string()],
+                server_name: "demo.mcp".to_string(),
+            },
+            pdp_client: Client::builder().timeout(Duration::from_secs(2)).build().unwrap(),
+            upstream_client: Client::builder().timeout(Duration::from_secs(2)).build().unwrap(),
+            controlplane_client: Client::builder().timeout(Duration::from_secs(2)).build().unwrap(),
+        }
+    }
+
+    async fn read_body(resp: axum::response::Response) -> Value {
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn allow_forwards_and_writes_receipt() {
+        let receipts: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let receipts_clone = receipts.clone();
+        let controlplane = Router::new().route(
+            "/v1/receipts",
+            post(move |Json(payload): Json<Value>| {
+                let receipts_clone = receipts_clone.clone();
+                async move {
+                    receipts_clone.lock().unwrap().push(payload);
+                    (
+                        StatusCode::CREATED,
+                        Json(json!({"receipt_id":"r1","hash":"h","prev_hash":""})),
+                    )
+                }
+            }),
+        );
+
+        let pdp = Router::new().route(
+            "/v1/decision",
+            post(|| async {
+                Json(json!({
+                    "decision":"allow",
+                    "decision_id":"dec-allow",
+                    "policy_hash":"hash",
+                    "policy_version":1,
+                    "reason":"ok"
+                }))
+            }),
+        );
+
+        let upstream = Router::new().route(
+            "/mcp",
+            post(|| async { Json(json!({"ok": true})) }),
+        );
+
+        let controlplane_url = start_server(controlplane).await;
+        let pdp_url = start_server(pdp).await;
+        let upstream_url = format!("{}/mcp", start_server(upstream).await);
+
+        let state = test_state(PepMode::Enforce, pdp_url, controlplane_url, upstream_url);
+        let app = Router::new()
+            .route("/mcp", post(handle_mcp))
+            .with_state(state);
+
+        let payload = json!({
+            "jsonrpc":"2.0",
+            "id":1,
+            "method":"tools/call",
+            "params":{
+                "name":"demo.tool",
+                "arguments":{"k":"v"},
+                "request_id":"req-1"
+            }
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mcp")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let stored = receipts.lock().unwrap();
+        assert_eq!(stored.len(), 1);
+        let receipt = &stored[0];
+        assert_eq!(receipt["outcome"], "success");
+        assert_eq!(receipt["method"], "tools/call");
+        assert_eq!(receipt["tool_name"], "demo.mcp:demo.tool");
+        assert_eq!(receipt["decision_id"], "dec-allow");
+        assert_eq!(receipt["body"]["enforcement"], "forwarded");
+    }
+
+    #[tokio::test]
+    async fn deny_blocks_in_enforce_mode() {
+        let receipts: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let receipts_clone = receipts.clone();
+        let controlplane = Router::new().route(
+            "/v1/receipts",
+            post(move |Json(payload): Json<Value>| {
+                let receipts_clone = receipts_clone.clone();
+                async move {
+                    receipts_clone.lock().unwrap().push(payload);
+                    (
+                        StatusCode::CREATED,
+                        Json(json!({"receipt_id":"r1","hash":"h","prev_hash":""})),
+                    )
+                }
+            }),
+        );
+
+        let pdp = Router::new().route(
+            "/v1/decision",
+            post(|| async {
+                Json(json!({
+                    "decision":"deny",
+                    "decision_id":"dec-deny",
+                    "policy_hash":"hash",
+                    "policy_version":1,
+                    "reason":"no"
+                }))
+            }),
+        );
+
+        let upstream = Router::new().route(
+            "/mcp",
+            post(|| async { Json(json!({"ok": true})) }),
+        );
+
+        let controlplane_url = start_server(controlplane).await;
+        let pdp_url = start_server(pdp).await;
+        let upstream_url = format!("{}/mcp", start_server(upstream).await);
+
+        let state = test_state(PepMode::Enforce, pdp_url, controlplane_url, upstream_url);
+        let app = Router::new()
+            .route("/mcp", post(handle_mcp))
+            .with_state(state);
+
+        let payload = json!({
+            "jsonrpc":"2.0",
+            "id":1,
+            "method":"tools/call",
+            "params":{"name":"demo.tool","request_id":"req-2"}
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mcp")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body = read_body(resp).await;
+        assert_eq!(body["error"]["data"]["error_code"], "POLICY_DENIED");
+
+        let stored = receipts.lock().unwrap();
+        assert_eq!(stored.len(), 1);
+        let receipt = &stored[0];
+        assert_eq!(receipt["outcome"], "denied");
+        assert_eq!(receipt["body"]["enforcement"], "blocked");
+        assert_eq!(receipt["decision_id"], "dec-deny");
+    }
+
+    #[tokio::test]
+    async fn pdp_unavailable_blocks_in_enforce_mode() {
+        let receipts: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let receipts_clone = receipts.clone();
+        let controlplane = Router::new().route(
+            "/v1/receipts",
+            post(move |Json(payload): Json<Value>| {
+                let receipts_clone = receipts_clone.clone();
+                async move {
+                    receipts_clone.lock().unwrap().push(payload);
+                    (
+                        StatusCode::CREATED,
+                        Json(json!({"receipt_id":"r1","hash":"h","prev_hash":""})),
+                    )
+                }
+            }),
+        );
+
+        let pdp = Router::new().route(
+            "/v1/decision",
+            post(|| async { (StatusCode::INTERNAL_SERVER_ERROR, "boom") }),
+        );
+
+        let controlplane_url = start_server(controlplane).await;
+        let pdp_url = start_server(pdp).await;
+
+        let state = test_state(PepMode::Enforce, pdp_url, controlplane_url, "http://localhost:0".to_string());
+        let app = Router::new()
+            .route("/mcp", post(handle_mcp))
+            .with_state(state);
+
+        let payload = json!({
+            "jsonrpc":"2.0",
+            "id":1,
+            "method":"tools/call",
+            "params":{"name":"demo.tool","request_id":"req-3"}
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mcp")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = read_body(resp).await;
+        assert_eq!(body["error"]["data"]["error_code"], "POLICY_UNAVAILABLE");
+
+        let stored = receipts.lock().unwrap();
+        assert_eq!(stored.len(), 1);
+        let receipt = &stored[0];
+        assert_eq!(receipt["body"]["pdp_status"], "unavailable");
+    }
+}

--- a/identity/control-plane/ui/app/policies/page.tsx
+++ b/identity/control-plane/ui/app/policies/page.tsx
@@ -34,6 +34,7 @@ export default function PoliciesPage() {
   const [items, setItems] = React.useState<PolicyRow[]>([]);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  const refreshControllerRef = React.useRef<AbortController | null>(null);
   const { hasRole } = useAuth();
   const canManagePolicies = hasRole("policy_admin");
 
@@ -75,7 +76,7 @@ export default function PoliciesPage() {
       const data = await api.listPolicies(signal);
       setItems(data.items ?? []);
       try {
-        const active = await api.getActivePolicy();
+        const active = await api.getActivePolicy(signal);
         setActivePolicy(active);
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : "";
@@ -94,13 +95,19 @@ export default function PoliciesPage() {
   }
 
   function handleRefresh() {
-    void refresh();
+    refreshControllerRef.current?.abort();
+    const controller = new AbortController();
+    refreshControllerRef.current = controller;
+    void refresh(controller.signal);
   }
 
   React.useEffect(() => {
     const controller = new AbortController();
     refresh(controller.signal);
-    return () => controller.abort();
+    return () => {
+      controller.abort();
+      refreshControllerRef.current?.abort();
+    };
   }, []);
 
   function validateOnly(): boolean {
@@ -129,9 +136,9 @@ export default function PoliciesPage() {
     const ok = validateOnly();
     if (!ok) return;
 
-    const parsed: unknown = JSON.parse(policy);
+    const parsed = PolicySchema.parse(JSON.parse(policy));
     try {
-      await api.createPolicy({ name, policy: parsed as Record<string, unknown> });
+      await api.createPolicy({ name, policy: parsed });
       await refresh();
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Create failed");
@@ -213,9 +220,9 @@ export default function PoliciesPage() {
     }
     const ok = validateEdit();
     if (!ok) return;
-    const parsed: unknown = JSON.parse(editPolicy);
+    const parsed = PolicySchema.parse(JSON.parse(editPolicy));
     try {
-      await api.updatePolicy(editing.id, { policy: parsed as Record<string, unknown> });
+      await api.updatePolicy(editing.id, { policy: parsed });
       setEditOpen(false);
       setEditing(null);
       await refresh();

--- a/identity/control-plane/ui/app/receipts/page.tsx
+++ b/identity/control-plane/ui/app/receipts/page.tsx
@@ -48,6 +48,8 @@ export default function ReceiptsPage() {
     kind: string;
     failure?: { receipt_id: string; code: string };
   } | null>(null);
+  const verifyControllerRef = React.useRef<AbortController | null>(null);
+  const refreshControllerRef = React.useRef<AbortController | null>(null);
   const [verifyError, setVerifyError] = React.useState<string | null>(null);
   const [verifyLoading, setVerifyLoading] = React.useState(false);
   const verifyEnabled = process.env.NEXT_PUBLIC_RECEIPTS_VERIFY_ENABLED === "true";
@@ -105,6 +107,12 @@ export default function ReceiptsPage() {
     }
     setSelectedJSON(JSON.stringify(selected, null, 2));
   }, [selected]);
+  React.useEffect(() => {
+    return () => {
+      verifyControllerRef.current?.abort();
+      refreshControllerRef.current?.abort();
+    };
+  }, []);
 
   async function runVerify() {
     if (!canViewReceipts) return;
@@ -113,12 +121,18 @@ export default function ReceiptsPage() {
     setVerifyResult(null);
     setVerifyLoading(true);
     try {
-      const res = await api.verifyReceipts({ kind: "all", limit: 100 });
+      verifyControllerRef.current?.abort();
+      const controller = new AbortController();
+      verifyControllerRef.current = controller;
+      const res = await api.verifyReceipts({ kind: "all", limit: 100 }, controller.signal);
       setVerifyResult(res);
     } catch (e: unknown) {
+      if (verifyControllerRef.current?.signal.aborted) return;
       setVerifyError(e instanceof Error ? e.message : "Verification failed");
     } finally {
-      setVerifyLoading(false);
+      if (!verifyControllerRef.current?.signal.aborted) {
+        setVerifyLoading(false);
+      }
     }
   }
 
@@ -195,7 +209,18 @@ export default function ReceiptsPage() {
                 {verifyLoading ? "Verifying…" : "Verify integrity"}
               </Button>
             )}
-            <Button variant="secondary" onClick={() => load(true)} disabled={loading}>Refresh</Button>
+            <Button
+              variant="secondary"
+              onClick={() => {
+                refreshControllerRef.current?.abort();
+                const controller = new AbortController();
+                refreshControllerRef.current = controller;
+                load(true, controller.signal);
+              }}
+              disabled={loading}
+            >
+              Refresh
+            </Button>
           </>
         )}
       />
@@ -315,7 +340,16 @@ export default function ReceiptsPage() {
                   <TableCell className="text-right">
                     <Dialog>
                       <DialogTrigger asChild>
-                        <Button size="sm" variant="outline" onClick={() => setSelected(r)}>View</Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => {
+                            setSelected(r);
+                            setSelectedJSON(JSON.stringify(r, null, 2));
+                          }}
+                        >
+                          View
+                        </Button>
                       </DialogTrigger>
                       <DialogContent className="max-w-4xl">
                         <DialogHeader>
@@ -335,14 +369,14 @@ export default function ReceiptsPage() {
                         <div className="mt-4">
                           <div className="mb-2 text-xs text-muted-foreground">Raw JSON</div>
                           <pre className="code text-xs bg-muted p-4 rounded-md overflow-auto max-h-[45vh]">
-{selectedJSON || JSON.stringify(r, null, 2)}
+{selectedJSON}
                           </pre>
                         </div>
 
                         <DialogFooter>
                           <Button
                             variant="secondary"
-                            onClick={() => navigator.clipboard.writeText(selectedJSON || JSON.stringify(r, null, 2))}
+                            onClick={() => navigator.clipboard.writeText(selectedJSON)}
                           >
                             Copy JSON
                           </Button>

--- a/identity/control-plane/ui/app/tools/page.tsx
+++ b/identity/control-plane/ui/app/tools/page.tsx
@@ -21,6 +21,7 @@ export default function ToolsPage() {
   const [items, setItems] = React.useState<Tool[]>([]);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  const refreshControllerRef = React.useRef<AbortController | null>(null);
   const { hasRole } = useAuth();
   const canManageTools = hasRole("tool_admin");
 
@@ -43,13 +44,19 @@ export default function ToolsPage() {
   }
 
   function handleRefresh() {
-    void refresh();
+    refreshControllerRef.current?.abort();
+    const controller = new AbortController();
+    refreshControllerRef.current = controller;
+    void refresh(controller.signal);
   }
 
   React.useEffect(() => {
     const controller = new AbortController();
     refresh(controller.signal);
-    return () => controller.abort();
+    return () => {
+      controller.abort();
+      refreshControllerRef.current?.abort();
+    };
   }, []);
 
   async function create() {

--- a/identity/control-plane/ui/lib/api.ts
+++ b/identity/control-plane/ui/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   SimulateResponse,
   Tool,
 } from "./types";
+import { ReceiptListSchema } from "./types";
 
 const BASE_URL = "/api/controlplane";
 const TENANT_KEY = "umbra.tenant_id";
@@ -45,7 +46,8 @@ export const api = {
   listTools: async (signal?: AbortSignal): Promise<{ items: Tool[] }> => {
     const result = await getClient().GET("/v1/tools", signal ? { signal } : {});
     const data = await unwrap<ToolList>(result);
-    return { items: (data.items ?? []) as Tool[] };
+    const items: Tool[] = data.items ?? [];
+    return { items };
   },
   createTool: async (body: CreateToolRequest): Promise<{ id: string }> => {
     const result = await getClient().POST("/v1/tools", { body });
@@ -57,7 +59,8 @@ export const api = {
   listPolicies: async (signal?: AbortSignal): Promise<{ items: PolicyRow[] }> => {
     const result = await getClient().GET("/v1/policies", signal ? { signal } : {});
     const data = await unwrap<PolicyList>(result);
-    return { items: (data.items ?? []) as PolicyRow[] };
+    const items: PolicyRow[] = data.items ?? [];
+    return { items };
   },
   createPolicy: async (body: CreatePolicyRequest): Promise<{ id: string }> => {
     const result = await getClient().POST("/v1/policies", { body });
@@ -74,7 +77,7 @@ export const api = {
       const text = await res.text().catch(() => "");
       throw new Error(text || `HTTP ${res.status}`);
     }
-    const data = (await res.json()) as PolicyRow;
+    const data: PolicyRow = await res.json();
     return { id: data.id };
   },
   activatePolicy: async (id: string): Promise<{ ok?: boolean }> => {
@@ -83,8 +86,8 @@ export const api = {
     });
     return unwrap(result);
   },
-  getActivePolicy: async (): Promise<ActivePolicyResponse> => {
-    const result = await getClient().GET("/v1/policies/active");
+  getActivePolicy: async (signal?: AbortSignal): Promise<ActivePolicyResponse> => {
+    const result = await getClient().GET("/v1/policies/active", signal ? { signal } : {});
     return unwrap<ActivePolicyResponse>(result);
   },
   simulatePolicyServer: async (body: SimulateRequest): Promise<SimulateResponse> => {
@@ -102,15 +105,23 @@ export const api = {
       ...(signal ? { signal } : {}),
     });
     const data = await unwrap<ReceiptList>(result);
-    const next = data.next_before;
+    const parsed = ReceiptListSchema.safeParse(data);
+    if (!parsed.success) {
+      throw new Error("Invalid receipts response");
+    }
+    const next = parsed.data.next_before;
     return {
-      items: (data.items ?? []) as Receipt[],
+      items: parsed.data.items ?? [],
       ...(next ? { next_before: next } : {}),
     };
   },
-  verifyReceipts: async (params: { kind?: "decision" | "invocation" | "all"; limit?: number } = {}): Promise<ReceiptVerifyResponse> => {
+  verifyReceipts: async (
+    params: { kind?: "decision" | "invocation" | "all"; limit?: number } = {},
+    signal?: AbortSignal,
+  ): Promise<ReceiptVerifyResponse> => {
     const result = await getClient().POST("/v1/receipts/verify", {
       params: { query: params },
+      ...(signal ? { signal } : {}),
     });
     return unwrap<ReceiptVerifyResponse>(result);
   },

--- a/identity/control-plane/ui/lib/auth/auth-context.tsx
+++ b/identity/control-plane/ui/lib/auth/auth-context.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { z } from "zod";
 
 type AuthUser = {
   id: string;
@@ -23,11 +24,12 @@ const DEFAULT_ROLES = ["developer", "tool_admin", "policy_admin", "auditor"];
 
 const AuthContext = React.createContext<AuthContextValue | null>(null);
 
-type SessionResponse = {
-  user?: AuthUser | null;
-  roles?: string[];
-  tenant_id?: string;
-};
+const SessionResponseSchema = z.object({
+  user: z.object({ id: z.string(), name: z.string().optional() }).nullable().optional(),
+  roles: z.array(z.string()).optional(),
+  tenant_id: z.string().optional(),
+});
+type SessionResponse = z.infer<typeof SessionResponseSchema>;
 
 function parseRoles(input?: string | null): string[] {
   if (!input) return [];
@@ -84,14 +86,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setUser(resolveUser(enabled));
       setTenantId(resolveTenant());
     };
-    const refreshSession = async () => {
+    const refreshSession = async (signal?: AbortSignal) => {
       try {
-        const res = await fetch("/api/auth/session");
+        const res = await fetch("/api/auth/session", signal ? { signal } : undefined);
         if (!res.ok) return;
-        const data = (await res.json()) as SessionResponse;
+        const json = await res.json();
+        const parsed = SessionResponseSchema.safeParse(json);
+        if (!parsed.success) return;
+        const data: SessionResponse = parsed.data;
         if (cancelled) return;
         setRoles(data.roles ?? []);
-        setUser(data.user ?? null);
+        const normalizedUser = data.user
+          ? {
+              id: data.user.id,
+              ...(data.user.name ? { name: data.user.name } : {}),
+            }
+          : null;
+        setUser(normalizedUser);
         setTenantId(data.tenant_id);
       } catch {
         if (!cancelled) {
@@ -103,11 +114,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
 
     if (enabled) {
-      void refreshSession();
-      const focusHandler = () => refreshSession();
+      const controller = new AbortController();
+      void refreshSession(controller.signal);
+      const focusHandler = () => refreshSession(controller.signal);
       window.addEventListener("focus", focusHandler);
       return () => {
         cancelled = true;
+        controller.abort();
         window.removeEventListener("focus", focusHandler);
       };
     }

--- a/identity/control-plane/ui/lib/types.ts
+++ b/identity/control-plane/ui/lib/types.ts
@@ -1,44 +1,54 @@
 import type { components } from "@contracts/openapi";
+import { z } from "zod";
 
 export type UUID = string;
 
-export type ReceiptKind = "decision" | "invocation";
+export const ReceiptKindSchema = z.enum(["decision", "invocation"]);
+export type ReceiptKind = z.infer<typeof ReceiptKindSchema>;
 
-export type DecisionReceipt = {
-  kind: "decision";
-  id: UUID;
-  ts: string;
-  decision_id: UUID;
-  decision: "allow" | "deny";
-  policy_hash?: string;
-  request_id?: string;
-  hash: string;
-  prev_hash?: string;
-  trace_id?: string;
-  span_id?: string;
-};
+export const DecisionReceiptSchema = z.object({
+  kind: z.literal("decision"),
+  id: z.string(),
+  ts: z.string(),
+  decision_id: z.string().optional().nullable(),
+  decision: z.enum(["allow", "deny"]),
+  policy_hash: z.string().optional().nullable(),
+  request_id: z.string().optional().nullable(),
+  hash: z.string(),
+  prev_hash: z.string().optional().nullable(),
+  trace_id: z.string().optional().nullable(),
+  span_id: z.string().optional().nullable(),
+});
+export type DecisionReceipt = z.infer<typeof DecisionReceiptSchema>;
 
-export type InvocationReceipt = {
-  kind: "invocation";
-  id: UUID;
-  ts: string;
-  decision_id: UUID;
-  request_id?: string;
-  tool_name: string;
-  method: string;
-  path: string;
-  outcome: "success" | "denied" | "error";
-  status_code: number;
-  latency_ms: number;
-  policy_hash?: string;
-  policy_version?: number;
-  hash: string;
-  prev_hash?: string;
-  trace_id?: string;
-  span_id?: string;
-};
+export const InvocationReceiptSchema = z.object({
+  kind: z.literal("invocation"),
+  id: z.string(),
+  ts: z.string(),
+  decision_id: z.string().optional().nullable(),
+  request_id: z.string().optional().nullable(),
+  tool_name: z.string(),
+  method: z.string(),
+  path: z.string(),
+  outcome: z.enum(["success", "denied", "error"]),
+  status_code: z.number().optional().nullable(),
+  latency_ms: z.number().optional().nullable(),
+  policy_hash: z.string().optional().nullable(),
+  policy_version: z.number().optional().nullable(),
+  hash: z.string(),
+  prev_hash: z.string().optional().nullable(),
+  trace_id: z.string().optional().nullable(),
+  span_id: z.string().optional().nullable(),
+});
+export type InvocationReceipt = z.infer<typeof InvocationReceiptSchema>;
 
-export type Receipt = DecisionReceipt | InvocationReceipt;
+export const ReceiptSchema = z.discriminatedUnion("kind", [DecisionReceiptSchema, InvocationReceiptSchema]);
+export type Receipt = z.infer<typeof ReceiptSchema>;
+
+export const ReceiptListSchema = z.object({
+  items: z.array(ReceiptSchema).optional(),
+  next_before: z.string().optional(),
+});
 
 export type Tool = components["schemas"]["Tool"];
 

--- a/identity/control-plane/ui/playwright.config.js
+++ b/identity/control-plane/ui/playwright.config.js
@@ -9,6 +9,10 @@ module.exports = defineConfig({
   retries: 0,
   use: {
     baseURL,
+    launchOptions: {
+      headless: true,
+      args: ["--headless=new"],
+    },
     trace: "retain-on-failure",
   },
 });


### PR DESCRIPTION
Resolved https://github.com/srehcs/umbra/issues/17 and https://github.com/srehcs/umbra/issues/14

Added compose profiles to make Rust PEP opt‑in and observability optional in dev.
Introduced make dev-min for a minimal stack (UI + API + PDP + Postgres).
Documented dev stack options in ADRs and READMEs.
Tightened UI/runtime validation and streaming export behavior.
Key Changes

New ADRs: optional Rust PEP profile, minimal dev stack target.
Compose updates: obs profile (redis/otel/jaeger), rust-pep profile.
Makefile targets: dev-min, dev-rust, default dev uses obs.
UI: Zod schemas for receipts and auth session handling, abortable fetches.
API: receipt export streaming and JSON export improvements.
Playwright: explicit headless config.
Testing

make lint
make test
pnpm lint
pnpm test:e2e (if applicable)