### PR TITLE
chore: unify error envelopes and request IDs

### DIFF
--- a/identity/control-plane/docs/README.md
+++ b/identity/control-plane/docs/README.md
@@ -17,6 +17,7 @@
 
 ## API contract
 - `api/openapi.yaml`
+- `api/error_envelope.md`
 
 ## Security
 - `security/path_to_oidc_keycloak.md`

--- a/identity/control-plane/docs/api/error_envelope.md
+++ b/identity/control-plane/docs/api/error_envelope.md
@@ -1,0 +1,46 @@
+# Error Envelope
+
+All HTTP APIs return a consistent error envelope:
+
+```json
+{
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "human-readable message",
+    "details": [
+      { "field": "field_name", "message": "validation message" }
+    ]
+  },
+  "request_id": "uuid"
+}
+```
+
+Notes:
+- `details` is optional and only used for validation errors.
+- `request_id` is always present (generated server-side if missing).
+
+## JSON-RPC (MCP Adapter)
+
+The MCP adapter uses JSON-RPC error responses and maps the same envelope into
+`error.data`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "rpc-id",
+  "error": {
+    "code": -32000,
+    "message": "upstream error",
+    "data": {
+      "error": {
+        "code": "UPSTREAM_ERROR",
+        "message": "upstream error"
+      },
+      "request_id": "uuid",
+      "decision_id": "uuid"
+    }
+  }
+}
+```
+
+This keeps error semantics consistent across HTTP and JSON-RPC surfaces.

--- a/identity/control-plane/docs/api/openapi.yaml
+++ b/identity/control-plane/docs/api/openapi.yaml
@@ -360,22 +360,26 @@ components:
     ErrorResponse:
       type: object
       properties:
-        error_code:
-          type: string
-          description: Stable error identifier (service-specific until error-envelope work is complete).
-        message: { type: string }
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              description: Stable error identifier.
+            message: { type: string }
+            details:
+              type: array
+              description: Optional field-level validation issues.
+              items:
+                type: object
+                properties:
+                  field: { type: string }
+                  message: { type: string }
+          required: [code, message]
         request_id: { type: string }
         decision_id: { type: string }
         trace_id: { type: string }
-        errors:
-          type: array
-          description: Optional field-level validation issues.
-          items:
-            type: object
-            properties:
-              field: { type: string }
-              message: { type: string }
-      required: [error_code, message]
+      required: [error]
 
     TenantContext:
       type: object

--- a/identity/control-plane/docs/runbooks/pdp_unavailable.md
+++ b/identity/control-plane/docs/runbooks/pdp_unavailable.md
@@ -22,7 +22,7 @@ When the PDP is unreachable or timing out, the PEP enforces a fail-closed postur
   - Risk: longer timeouts increase tail latency and can cascade under load.
 
 ## Expected client behavior
-- `enforce` mode: requests return `503` with `error_code=POLICY_UNAVAILABLE`.
+- `enforce` mode: requests return `503` with `error.code=POLICY_UNAVAILABLE`.
 - `observe` mode: requests are forwarded, but receipts capture PDP unavailability.
 
 ## Recovery checklist

--- a/identity/control-plane/packages/contracts/openapi.ts
+++ b/identity/control-plane/packages/contracts/openapi.ts
@@ -54,17 +54,17 @@ export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
     ErrorResponse: {
-      /** @description Stable error identifier (service-specific until error-envelope work is complete). */
-      error_code: string;
-      message: string;
+      error: {
+        code: string;
+        message: string;
+        details?: {
+            field?: string;
+            message?: string;
+          }[];
+      };
       request_id?: string;
       decision_id?: string;
       trace_id?: string;
-      /** @description Optional field-level validation issues. */
-      errors?: {
-          field?: string;
-          message?: string;
-        }[];
     };
     TenantContext: {
       tenant_id: string;

--- a/identity/control-plane/packages/contracts/openapi.ts
+++ b/identity/control-plane/packages/contracts/openapi.ts
@@ -55,8 +55,10 @@ export interface components {
   schemas: {
     ErrorResponse: {
       error: {
+        /** @description Stable error identifier. */
         code: string;
         message: string;
+        /** @description Optional field-level validation issues. */
         details?: {
             field?: string;
             message?: string;

--- a/identity/control-plane/packages/go/protocol/error_codes.go
+++ b/identity/control-plane/packages/go/protocol/error_codes.go
@@ -1,0 +1,17 @@
+package protocol
+
+const (
+	ErrorCodeBadRequest         = "BAD_REQUEST"
+	ErrorCodeConflict           = "CONFLICT"
+	ErrorCodeDBError            = "DB_ERROR"
+	ErrorCodeInvalidJSON        = "INVALID_JSON"
+	ErrorCodeInvalidRequest     = "INVALID_REQUEST"
+	ErrorCodeInvalidTenant      = "INVALID_TENANT"
+	ErrorCodeMethodNotAllowed   = "METHOD_NOT_ALLOWED"
+	ErrorCodeMethodNotSupported = "METHOD_NOT_SUPPORTED"
+	ErrorCodeNotFound           = "NOT_FOUND"
+	ErrorCodePolicyDenied       = "POLICY_DENIED"
+	ErrorCodePolicyUnavailable  = "POLICY_UNAVAILABLE"
+	ErrorCodeStorageUnavailable = "STORAGE_UNAVAILABLE"
+	ErrorCodeUpstreamError      = "UPSTREAM_ERROR"
+)

--- a/identity/control-plane/services/controlplane-api/internal/http-api/contract_test.go
+++ b/identity/control-plane/services/controlplane-api/internal/http-api/contract_test.go
@@ -62,7 +62,7 @@ func TestControlPlaneContractOpenAPI(t *testing.T) {
 	assertSchemaExists(t, spec, "ActivePolicyResponse")
 
 	errResp := derefSchema(t, spec, spec.Components.Schemas["ErrorResponse"])
-	assertRequired(t, errResp.Required, "error_code", "message")
+	assertRequired(t, errResp.Required, "error")
 
 	receiptsPath := spec.Paths["/v1/receipts"]
 	if receiptsPath.Get == nil || receiptsPath.Post == nil {

--- a/identity/control-plane/services/controlplane-api/internal/http-api/v0.go
+++ b/identity/control-plane/services/controlplane-api/internal/http-api/v0.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/umbra-labs/agent-identity-control-plane/packages/go/policy"
+	"github.com/umbra-labs/agent-identity-control-plane/packages/go/protocol"
 	"github.com/umbra-labs/agent-identity-control-plane/packages/go/receipts"
 
 	"github.com/google/uuid"
@@ -60,6 +61,17 @@ type ListReceiptsResponse struct {
 type fieldError struct {
 	Field   string `json:"field"`
 	Message string `json:"message"`
+}
+
+type errorBody struct {
+	Code    string       `json:"code"`
+	Message string       `json:"message"`
+	Details []fieldError `json:"details,omitempty"`
+}
+
+type errorResponse struct {
+	Error     errorBody `json:"error"`
+	RequestID string    `json:"request_id,omitempty"`
 }
 
 type receiptIngestRequest struct {
@@ -129,12 +141,12 @@ func (s *Server) tenantFromRequest(r *http.Request) (uuid.UUID, error) {
 
 func (s *Server) handleTools(w http.ResponseWriter, r *http.Request) {
 	if s.Store == nil {
-		http.Error(w, "storage not configured", http.StatusServiceUnavailable)
+		writeErrorResponse(w, http.StatusServiceUnavailable, protocol.ErrorCodeStorageUnavailable, "storage not configured", nil, r)
 		return
 	}
 	tenant, err := s.tenantFromRequest(r)
 	if err != nil || tenant == uuid.Nil {
-		http.Error(w, "missing/invalid x-umbra-tenant-id", http.StatusBadRequest)
+		writeInvalidTenant(w, r)
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
@@ -144,7 +156,7 @@ func (s *Server) handleTools(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		items, err := s.Store.ListTools(ctx, tenant, 50)
 		if err != nil {
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		writeJSON(w, map[string]interface{}{"items": items})
@@ -155,33 +167,33 @@ func (s *Server) handleTools(w http.ResponseWriter, r *http.Request) {
 			Config json.RawMessage `json:"config"`
 		}
 		if err := decodeJSON(r, &body); err != nil {
-			http.Error(w, "invalid json", 400)
+			writeInvalidJSON(w, r)
 			return
 		}
 		if body.Name == "" || body.Kind == "" {
-			http.Error(w, "name and kind required", 400)
+			writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidRequest, "name and kind required", nil, r)
 			return
 		}
 		t, err := s.Store.CreateTool(ctx, tenant, body.Name, body.Kind, body.Config)
 		if err != nil {
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
 		writeJSON(w, t)
 	default:
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeMethodNotAllowed(w, r)
 	}
 }
 
 func (s *Server) handlePolicies(w http.ResponseWriter, r *http.Request) {
 	tenant, err := s.tenantFromRequest(r)
 	if err != nil || tenant == uuid.Nil {
-		http.Error(w, "missing/invalid x-umbra-tenant-id", http.StatusBadRequest)
+		writeInvalidTenant(w, r)
 		return
 	}
 	if s.Store == nil {
-		http.Error(w, "storage not configured", http.StatusServiceUnavailable)
+		writeErrorResponse(w, http.StatusServiceUnavailable, protocol.ErrorCodeStorageUnavailable, "storage not configured", nil, r)
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
@@ -191,7 +203,7 @@ func (s *Server) handlePolicies(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		items, err := s.Store.ListPolicies(ctx, tenant, 50)
 		if err != nil {
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		out := make([]policyResponse, 0, len(items))
@@ -205,27 +217,18 @@ func (s *Server) handlePolicies(w http.ResponseWriter, r *http.Request) {
 			Policy json.RawMessage `json:"policy"`
 		}
 		if err := decodeJSON(r, &body); err != nil {
-			http.Error(w, "invalid json", 400)
+			writeInvalidJSON(w, r)
 			return
 		}
 		if body.Name == "" || len(body.Policy) == 0 {
-			http.Error(w, "name and policy required", 400)
+			writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidRequest, "name and policy required", nil, r)
 			return
 		}
 
 		// Validate the policy
 		validationErrs, policyHash, policySize := policy.ValidatePolicyWithSize(body.Policy)
 		if len(validationErrs) > 0 {
-			w.WriteHeader(http.StatusBadRequest)
-			response := map[string]interface{}{
-				"code":    policy.ErrorCodePolicyInvalid,
-				"message": "policy validation failed",
-				"errors":  validationErrs,
-			}
-			if reqID := r.Header.Get("x-request-id"); reqID != "" {
-				response["request_id"] = reqID
-			}
-			writeJSON(w, response)
+			writeErrorResponse(w, http.StatusBadRequest, policy.ErrorCodePolicyInvalid, "policy validation failed", policyErrorsToFieldErrors(validationErrs), r)
 			s.Logger.Warn("policy validation failed",
 				"tenant_id", tenant.String(),
 				"policy_name", body.Name,
@@ -239,7 +242,7 @@ func (s *Server) handlePolicies(w http.ResponseWriter, r *http.Request) {
 		p, err := s.Store.CreatePolicy(ctx, tenant, body.Name, body.Policy, policyHash)
 		if err != nil {
 			s.Logger.Error("policy creation failed", "err", err)
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
@@ -251,34 +254,34 @@ func (s *Server) handlePolicies(w http.ResponseWriter, r *http.Request) {
 			"policy_hash", p.PolicyHash,
 		)
 	default:
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeMethodNotAllowed(w, r)
 	}
 }
 
 func (s *Server) handleActivatePolicy(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeMethodNotAllowed(w, r)
 		return
 	}
 	if s.Store == nil {
-		http.Error(w, "storage not configured", 503)
+		writeErrorResponse(w, http.StatusServiceUnavailable, protocol.ErrorCodeStorageUnavailable, "storage not configured", nil, r)
 		return
 	}
 	tenant, err := s.tenantFromRequest(r)
 	if err != nil || tenant == uuid.Nil {
-		http.Error(w, "missing/invalid x-umbra-tenant-id", 400)
+		writeInvalidTenant(w, r)
 		return
 	}
 	var body struct {
 		PolicyID string `json:"policy_id"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		http.Error(w, "invalid json", 400)
+		writeInvalidJSON(w, r)
 		return
 	}
 	pid, err := uuid.Parse(body.PolicyID)
 	if err != nil {
-		http.Error(w, "invalid policy_id", 400)
+		writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidRequest, "invalid policy_id", nil, r)
 		return
 	}
 	s.activatePolicyByID(w, r, tenant, pid)
@@ -286,12 +289,12 @@ func (s *Server) handleActivatePolicy(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handlePolicyByID(w http.ResponseWriter, r *http.Request) {
 	if s.Store == nil {
-		http.Error(w, "storage not configured", http.StatusServiceUnavailable)
+		writeErrorResponse(w, http.StatusServiceUnavailable, protocol.ErrorCodeStorageUnavailable, "storage not configured", nil, r)
 		return
 	}
 	tenant, err := s.tenantFromRequest(r)
 	if err != nil || tenant == uuid.Nil {
-		http.Error(w, "missing/invalid x-umbra-tenant-id", http.StatusBadRequest)
+		writeInvalidTenant(w, r)
 		return
 	}
 
@@ -305,13 +308,13 @@ func (s *Server) handlePolicyByID(w http.ResponseWriter, r *http.Request) {
 	parts := strings.Split(path, "/")
 	policyID, err := uuid.Parse(parts[0])
 	if err != nil {
-		http.Error(w, "invalid policy id", http.StatusBadRequest)
+		writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidRequest, "invalid policy id", nil, r)
 		return
 	}
 
 	if len(parts) == 2 && parts[1] == "activate" {
 		if r.Method != http.MethodPost {
-			w.WriteHeader(http.StatusMethodNotAllowed)
+			writeMethodNotAllowed(w, r)
 			return
 		}
 		s.activatePolicyByID(w, r, tenant, policyID)
@@ -325,10 +328,10 @@ func (s *Server) handlePolicyByID(w http.ResponseWriter, r *http.Request) {
 		p, err := s.Store.GetPolicy(ctx, tenant, policyID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				http.Error(w, "not found", http.StatusNotFound)
+				writeErrorResponse(w, http.StatusNotFound, protocol.ErrorCodeNotFound, "not found", nil, r)
 				return
 			}
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		writeJSON(w, policyResponseFrom(p))
@@ -337,26 +340,17 @@ func (s *Server) handlePolicyByID(w http.ResponseWriter, r *http.Request) {
 			Policy json.RawMessage `json:"policy"`
 		}
 		if err := decodeJSON(r, &body); err != nil {
-			http.Error(w, "invalid json", 400)
+			writeInvalidJSON(w, r)
 			return
 		}
 		if len(body.Policy) == 0 {
-			http.Error(w, "policy required", 400)
+			writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidRequest, "policy required", nil, r)
 			return
 		}
 
 		validationErrs, policyHash, policySize := policy.ValidatePolicyWithSize(body.Policy)
 		if len(validationErrs) > 0 {
-			w.WriteHeader(http.StatusBadRequest)
-			response := map[string]interface{}{
-				"code":    policy.ErrorCodePolicyInvalid,
-				"message": "policy validation failed",
-				"errors":  validationErrs,
-			}
-			if reqID := r.Header.Get("x-request-id"); reqID != "" {
-				response["request_id"] = reqID
-			}
-			writeJSON(w, response)
+			writeErrorResponse(w, http.StatusBadRequest, policy.ErrorCodePolicyInvalid, "policy validation failed", policyErrorsToFieldErrors(validationErrs), r)
 			s.Logger.Warn("policy validation failed",
 				"tenant_id", tenant.String(),
 				"policy_id", policyID.String(),
@@ -372,40 +366,40 @@ func (s *Server) handlePolicyByID(w http.ResponseWriter, r *http.Request) {
 		existing, err := s.Store.GetPolicy(ctx, tenant, policyID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				http.Error(w, "not found", http.StatusNotFound)
+				writeErrorResponse(w, http.StatusNotFound, protocol.ErrorCodeNotFound, "not found", nil, r)
 				return
 			}
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		if existing.Active {
-			http.Error(w, "cannot update active policy", http.StatusConflict)
+			writeErrorResponse(w, http.StatusConflict, protocol.ErrorCodeConflict, "cannot update active policy", nil, r)
 			return
 		}
 
 		p, err := s.Store.UpdatePolicy(ctx, tenant, policyID, body.Policy, policyHash)
 		if err != nil {
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		writeJSON(w, policyResponseFrom(p))
 	default:
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeMethodNotAllowed(w, r)
 	}
 }
 
 func (s *Server) handleActivePolicy(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeMethodNotAllowed(w, r)
 		return
 	}
 	if s.Store == nil {
-		http.Error(w, "storage not configured", 503)
+		writeErrorResponse(w, http.StatusServiceUnavailable, protocol.ErrorCodeStorageUnavailable, "storage not configured", nil, r)
 		return
 	}
 	tenant, err := s.tenantFromRequest(r)
 	if err != nil || tenant == uuid.Nil {
-		http.Error(w, "missing/invalid x-umbra-tenant-id", 400)
+		writeInvalidTenant(w, r)
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
@@ -413,10 +407,10 @@ func (s *Server) handleActivePolicy(w http.ResponseWriter, r *http.Request) {
 	p, err := s.Store.GetActivePolicy(ctx, tenant)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			http.Error(w, "no active policy", http.StatusNotFound)
+			writeErrorResponse(w, http.StatusNotFound, protocol.ErrorCodeNotFound, "no active policy", nil, r)
 			return
 		}
-		http.Error(w, "db error", 500)
+		writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 		return
 	}
 	writeJSON(w, map[string]interface{}{
@@ -435,34 +429,25 @@ func (s *Server) activatePolicyByID(w http.ResponseWriter, r *http.Request, tena
 	p, err := s.Store.GetPolicy(ctx, tenant, policyID)
 	if err != nil {
 		if errors.Is(err, stor.ErrNotFound) || errors.Is(err, pgx.ErrNoRows) {
-			http.Error(w, "not found", http.StatusNotFound)
+			writeErrorResponse(w, http.StatusNotFound, protocol.ErrorCodeNotFound, "not found", nil, r)
 			return
 		}
-		http.Error(w, "db error", 500)
+		writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 		return
 	}
 
 	validationErrs, _, _ := policy.ValidatePolicyWithSize(p.Policy)
 	if len(validationErrs) > 0 {
-		w.WriteHeader(http.StatusBadRequest)
-		response := map[string]interface{}{
-			"code":    policy.ErrorCodePolicyInvalid,
-			"message": "policy validation failed",
-			"errors":  validationErrs,
-		}
-		if reqID := r.Header.Get("x-request-id"); reqID != "" {
-			response["request_id"] = reqID
-		}
-		writeJSON(w, response)
+		writeErrorResponse(w, http.StatusBadRequest, policy.ErrorCodePolicyInvalid, "policy validation failed", policyErrorsToFieldErrors(validationErrs), r)
 		return
 	}
 
 	if err := s.Store.ActivatePolicy(ctx, tenant, policyID); err != nil {
 		if errors.Is(err, stor.ErrNotFound) {
-			http.Error(w, "not found", http.StatusNotFound)
+			writeErrorResponse(w, http.StatusNotFound, protocol.ErrorCodeNotFound, "not found", nil, r)
 			return
 		}
-		http.Error(w, "db error", 500)
+		writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 		return
 	}
 	writeJSON(w, map[string]interface{}{"ok": true})
@@ -470,12 +455,12 @@ func (s *Server) activatePolicyByID(w http.ResponseWriter, r *http.Request, tena
 
 func (s *Server) handleSimulatePolicy(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeMethodNotAllowed(w, r)
 		return
 	}
 	tenant, err := s.tenantFromRequest(r)
 	if err != nil || tenant == uuid.Nil {
-		http.Error(w, "missing/invalid x-umbra-tenant-id", 400)
+		writeInvalidTenant(w, r)
 		return
 	}
 
@@ -491,7 +476,7 @@ func (s *Server) handleSimulatePolicy(w http.ResponseWriter, r *http.Request) {
 		Policy     json.RawMessage `json:"policy,omitempty"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		http.Error(w, "invalid json", 400)
+		writeInvalidJSON(w, r)
 		return
 	}
 
@@ -507,16 +492,11 @@ func (s *Server) handleSimulatePolicy(w http.ResponseWriter, r *http.Request) {
 		// Validate the supplied policy
 		validationErrs, hash, _ := policy.ValidatePolicyWithSize(body.Policy)
 		if len(validationErrs) > 0 {
-			w.WriteHeader(http.StatusBadRequest)
-			response := map[string]interface{}{
-				"code":    policy.ErrorCodePolicyInvalid,
-				"message": "policy validation failed",
-				"errors":  validationErrs,
+			errs := make([]fieldError, 0, len(validationErrs))
+			for _, err := range validationErrs {
+				errs = append(errs, fieldError{Field: err.Path, Message: err.Message})
 			}
-			if reqID := r.Header.Get("x-request-id"); reqID != "" {
-				response["request_id"] = reqID
-			}
-			writeJSON(w, response)
+			writeErrorResponse(w, http.StatusBadRequest, policy.ErrorCodePolicyInvalid, "policy validation failed", errs, r)
 			return
 		}
 		policyData = body.Policy
@@ -524,13 +504,13 @@ func (s *Server) handleSimulatePolicy(w http.ResponseWriter, r *http.Request) {
 		policyVersion = 0 // Simulated policies don't have a version
 	} else {
 		if s.Store == nil {
-			http.Error(w, "storage not configured", 503)
+			writeErrorResponse(w, http.StatusServiceUnavailable, protocol.ErrorCodeStorageUnavailable, "storage not configured", nil, r)
 			return
 		}
 		// Fetch active policy
 		policies, err := s.Store.ListPolicies(ctx, tenant, 50)
 		if err != nil {
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		found := false
@@ -544,7 +524,7 @@ func (s *Server) handleSimulatePolicy(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if !found {
-			http.Error(w, "no active policy found", 404)
+			writeErrorResponse(w, http.StatusNotFound, protocol.ErrorCodeNotFound, "no active policy found", nil, r)
 			return
 		}
 	}
@@ -552,7 +532,7 @@ func (s *Server) handleSimulatePolicy(w http.ResponseWriter, r *http.Request) {
 	// Evaluate the policy
 	var pol policy.Policy
 	if err := json.Unmarshal(policyData, &pol); err != nil {
-		http.Error(w, "policy parse error", 400)
+		writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidRequest, "policy parse error", nil, r)
 		return
 	}
 
@@ -587,18 +567,18 @@ func (s *Server) handleReceipts(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPost:
 		s.handleReceiptsIngest(w, r)
 	default:
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeMethodNotAllowed(w, r)
 	}
 }
 
 func (s *Server) handleReceiptsList(w http.ResponseWriter, r *http.Request) {
 	if s.Store == nil {
-		http.Error(w, "storage not configured", 503)
+		writeErrorResponse(w, http.StatusServiceUnavailable, protocol.ErrorCodeStorageUnavailable, "storage not configured", nil, r)
 		return
 	}
 	tenant, err := s.tenantFromRequest(r)
 	if err != nil || tenant == uuid.Nil {
-		http.Error(w, "missing/invalid x-umbra-tenant-id", 400)
+		writeInvalidTenant(w, r)
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
@@ -620,7 +600,7 @@ func (s *Server) handleReceiptsList(w http.ResponseWriter, r *http.Request) {
 
 	items, next, err := s.Store.ListReceipts(ctx, tenant, limit, kind, q, before)
 	if err != nil {
-		http.Error(w, "db error", 500)
+		writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 		return
 	}
 
@@ -633,12 +613,12 @@ func (s *Server) handleReceiptsList(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleReceiptsIngest(w http.ResponseWriter, r *http.Request) {
 	if s.Store == nil {
-		http.Error(w, "storage not configured", 503)
+		writeErrorResponse(w, http.StatusServiceUnavailable, protocol.ErrorCodeStorageUnavailable, "storage not configured", nil, r)
 		return
 	}
 	tenant, err := s.tenantFromRequest(r)
 	if err != nil || tenant == uuid.Nil {
-		writeErrorResponse(w, http.StatusBadRequest, "INVALID_TENANT", "missing/invalid x-umbra-tenant-id", nil, r)
+		writeInvalidTenant(w, r)
 		return
 	}
 
@@ -679,13 +659,13 @@ func (s *Server) handleReceiptsIngest(w http.ResponseWriter, r *http.Request) {
 		}
 		prev, err := s.Store.LastDecisionHash(ctx, tenant)
 		if err != nil {
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		hash := receipts.HashBytes(append([]byte(prev), compactBody...))
 		id, err := s.Store.InsertDecisionReceipt(ctx, tenant, decisionID, body.RequestID, body.PolicyHash, body.Decision, compactBody, prev, hash, body.TraceID, body.SpanID)
 		if err != nil {
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
@@ -702,7 +682,7 @@ func (s *Server) handleReceiptsIngest(w http.ResponseWriter, r *http.Request) {
 		}
 		prev, err := s.Store.LastInvocationHash(ctx, tenant)
 		if err != nil {
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		hash := receipts.HashBytes(append([]byte(prev), compactBody...))
@@ -712,7 +692,7 @@ func (s *Server) handleReceiptsIngest(w http.ResponseWriter, r *http.Request) {
 		}
 		id, err := s.Store.InsertInvocationReceipt(ctx, tenant, decisionID, body.RequestID, body.ToolName, body.Method, body.Path, body.Outcome, body.StatusCode, latencyMs, compactBody, prev, hash, body.TraceID, body.SpanID)
 		if err != nil {
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
@@ -781,32 +761,64 @@ func containsArgsField(raw json.RawMessage) bool {
 }
 
 func writeErrorResponse(w http.ResponseWriter, status int, code string, message string, errs []fieldError, r *http.Request) {
-	resp := map[string]interface{}{
-		"error_code": code,
-		"message":    message,
+	reqID := ensureRequestID(r)
+	w.Header().Set("x-request-id", reqID)
+
+	payload := errorResponse{
+		Error:     errorBody{Code: code, Message: message},
+		RequestID: reqID,
 	}
 	if len(errs) > 0 {
-		resp["errors"] = errs
-	}
-	if reqID := r.Header.Get("x-request-id"); reqID != "" {
-		resp["request_id"] = reqID
+		payload.Error.Details = errs
 	}
 	w.WriteHeader(status)
-	writeJSON(w, resp)
+	writeJSON(w, payload)
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter, r *http.Request) {
+	writeErrorResponse(w, http.StatusMethodNotAllowed, protocol.ErrorCodeMethodNotAllowed, "method not allowed", nil, r)
+}
+
+func writeInvalidTenant(w http.ResponseWriter, r *http.Request) {
+	writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidTenant, "missing/invalid x-umbra-tenant-id", nil, r)
+}
+
+func writeInvalidJSON(w http.ResponseWriter, r *http.Request) {
+	writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidJSON, "invalid json", nil, r)
+}
+
+func policyErrorsToFieldErrors(errs []policy.ValidationError) []fieldError {
+	if len(errs) == 0 {
+		return nil
+	}
+	out := make([]fieldError, 0, len(errs))
+	for _, err := range errs {
+		out = append(out, fieldError{Field: err.Path, Message: err.Message})
+	}
+	return out
+}
+
+func ensureRequestID(r *http.Request) string {
+	reqID := strings.TrimSpace(r.Header.Get("x-request-id"))
+	if reqID == "" {
+		reqID = uuid.NewString()
+		r.Header.Set("x-request-id", reqID)
+	}
+	return reqID
 }
 
 func (s *Server) handleReceiptsExport(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeMethodNotAllowed(w, r)
 		return
 	}
 	if s.Store == nil {
-		http.Error(w, "storage not configured", 503)
+		writeErrorResponse(w, http.StatusServiceUnavailable, protocol.ErrorCodeStorageUnavailable, "storage not configured", nil, r)
 		return
 	}
 	tenant, err := s.tenantFromRequest(r)
 	if err != nil || tenant == uuid.Nil {
-		http.Error(w, "missing/invalid x-umbra-tenant-id", 400)
+		writeInvalidTenant(w, r)
 		return
 	}
 
@@ -816,7 +828,7 @@ func (s *Server) handleReceiptsExport(w http.ResponseWriter, r *http.Request) {
 		format = "json"
 	}
 	if format != "json" && format != "csv" {
-		http.Error(w, "invalid format", 400)
+		writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidRequest, "invalid format", nil, r)
 		return
 	}
 
@@ -824,7 +836,7 @@ func (s *Server) handleReceiptsExport(w http.ResponseWriter, r *http.Request) {
 	if from := strings.TrimSpace(q.Get("from")); from != "" {
 		t, err := time.Parse(time.RFC3339, from)
 		if err != nil {
-			http.Error(w, "invalid from", 400)
+			writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidRequest, "invalid from", nil, r)
 			return
 		}
 		fromPtr = &t
@@ -833,7 +845,7 @@ func (s *Server) handleReceiptsExport(w http.ResponseWriter, r *http.Request) {
 	if to := strings.TrimSpace(q.Get("to")); to != "" {
 		t, err := time.Parse(time.RFC3339, to)
 		if err != nil {
-			http.Error(w, "invalid to", 400)
+			writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidRequest, "invalid to", nil, r)
 			return
 		}
 		toPtr = &t
@@ -841,7 +853,7 @@ func (s *Server) handleReceiptsExport(w http.ResponseWriter, r *http.Request) {
 
 	decision := strings.ToLower(strings.TrimSpace(q.Get("decision")))
 	if decision != "" && decision != "allow" && decision != "deny" {
-		http.Error(w, "invalid decision", 400)
+		writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidRequest, "invalid decision", nil, r)
 		return
 	}
 
@@ -870,29 +882,29 @@ func (s *Server) handleReceiptsExport(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", "text/csv")
 		w.Header().Set("content-disposition", "attachment; filename=receipts_export.csv")
 		if err := s.Store.ExportReceiptsCSV(ctx, tenant, filters, w); err != nil {
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 		}
 		return
 	}
 
 	w.Header().Set("content-type", "application/json")
 	if err := s.Store.ExportReceiptsJSON(ctx, tenant, filters, w); err != nil {
-		http.Error(w, "db error", 500)
+		writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 	}
 }
 
 func (s *Server) handleReceiptsVerify(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeMethodNotAllowed(w, r)
 		return
 	}
 	if s.Store == nil {
-		http.Error(w, "storage not configured", 503)
+		writeErrorResponse(w, http.StatusServiceUnavailable, protocol.ErrorCodeStorageUnavailable, "storage not configured", nil, r)
 		return
 	}
 	tenant, err := s.tenantFromRequest(r)
 	if err != nil || tenant == uuid.Nil {
-		http.Error(w, "missing/invalid x-umbra-tenant-id", 400)
+		writeInvalidTenant(w, r)
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
@@ -922,10 +934,10 @@ func (s *Server) handleReceiptsVerify(w http.ResponseWriter, r *http.Request) {
 		res, err := verifyKind(kind)
 		if err != nil {
 			if errors.Is(err, stor.ErrNotFound) {
-				http.Error(w, "invalid kind", 400)
+				writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidRequest, "invalid kind", nil, r)
 				return
 			}
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		writeJSON(w, map[string]interface{}{
@@ -937,7 +949,7 @@ func (s *Server) handleReceiptsVerify(w http.ResponseWriter, r *http.Request) {
 	case "all":
 		res, err := verifyKind("decision")
 		if err != nil {
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		if !res.OK {
@@ -951,7 +963,7 @@ func (s *Server) handleReceiptsVerify(w http.ResponseWriter, r *http.Request) {
 		}
 		resInv, err := verifyKind("invocation")
 		if err != nil {
-			http.Error(w, "db error", 500)
+			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
 		if !resInv.OK {
@@ -969,7 +981,7 @@ func (s *Server) handleReceiptsVerify(w http.ResponseWriter, r *http.Request) {
 			"kind":    "all",
 		})
 	default:
-		http.Error(w, "invalid kind", 400)
+		writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidRequest, "invalid kind", nil, r)
 	}
 }
 

--- a/identity/control-plane/services/controlplane-api/internal/http-api/v0_test.go
+++ b/identity/control-plane/services/controlplane-api/internal/http-api/v0_test.go
@@ -354,11 +354,14 @@ func TestHandleSimulatePolicy_WithInvalidPolicy(t *testing.T) {
 	respBytes, _ := io.ReadAll(w.Body)
 	json.Unmarshal(respBytes, &resp)
 
-	if code, ok := resp["code"]; !ok || code != policy.ErrorCodePolicyInvalid {
+	errObj, ok := resp["error"].(map[string]interface{})
+	if !ok {
+		t.Fatal("response should contain 'error'")
+	}
+	if code, ok := errObj["code"]; !ok || code != policy.ErrorCodePolicyInvalid {
 		t.Errorf("expected code '%s', got %v", policy.ErrorCodePolicyInvalid, code)
 	}
-
-	if _, ok := resp["errors"]; !ok {
-		t.Error("response should contain 'errors'")
+	if _, ok := errObj["details"]; !ok {
+		t.Error("response should contain 'error.details'")
 	}
 }

--- a/identity/control-plane/services/mcp-adapter/internal/http-api/v0.go
+++ b/identity/control-plane/services/mcp-adapter/internal/http-api/v0.go
@@ -113,6 +113,17 @@ type rpcError struct {
 	Data    interface{} `json:"data,omitempty"`
 }
 
+type rpcErrorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type rpcErrorData struct {
+	Error      rpcErrorBody `json:"error"`
+	RequestID  string       `json:"request_id,omitempty"`
+	DecisionID string       `json:"decision_id,omitempty"`
+}
+
 type toolCallParams struct {
 	Name              string                 `json:"name"`
 	Arguments         map[string]interface{} `json:"arguments,omitempty"`
@@ -247,24 +258,24 @@ func registerV0(mux *http.ServeMux, logger *slog.Logger) {
 
 func (h *mcpHandler) handleMCP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeRPCMethodNotAllowed(w)
 		return
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
-		writeRPCError(w, http.StatusBadRequest, nil, "invalid request", "BAD_REQUEST", "")
+		writeRPCBadRequest(w, nil, "invalid request", "")
 		return
 	}
 
 	var req rpcRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		writeRPCError(w, http.StatusBadRequest, nil, "invalid json", "BAD_REQUEST", "")
+		writeRPCBadRequest(w, nil, "invalid json", "")
 		return
 	}
 
 	if strings.TrimSpace(req.Method) != "tools/call" {
-		writeRPCError(w, http.StatusBadRequest, req.ID, "method not supported", "METHOD_NOT_SUPPORTED", "")
+		writeRPCMethodNotSupported(w, req.ID)
 		return
 	}
 
@@ -475,7 +486,7 @@ func (h *mcpHandler) handleMCP(w http.ResponseWriter, r *http.Request) {
 		forwardBody, err := buildForwardBody(req, params)
 		if err != nil {
 			writeInvocationReceipt(ctx, logger, h.store, tenantID, decisionID, requestID, actor, mcpCtx, policyHash, policyVersion, outcome, intPtr(http.StatusBadRequest), pdpLatency, toolLatency, int(time.Since(started).Milliseconds()), meta, started, h.pepMode, enforcement, pdpStatus, traceID, spanID)
-			writeRPCError(w, http.StatusBadRequest, req.ID, "invalid request", "BAD_REQUEST", requestID)
+			writeRPCError(w, http.StatusBadRequest, req.ID, "invalid request", protocol.ErrorCodeBadRequest, requestID)
 			return
 		}
 
@@ -492,7 +503,7 @@ func (h *mcpHandler) handleMCP(w http.ResponseWriter, r *http.Request) {
 		toolLatency = int(time.Since(toolStarted).Milliseconds())
 		if err != nil {
 			writeInvocationReceipt(ctx, logger, h.store, tenantID, decisionID, requestID, actor, mcpCtx, policyHash, policyVersion, "error", intPtr(http.StatusBadGateway), pdpLatency, toolLatency, int(time.Since(started).Milliseconds()), meta, started, h.pepMode, enforcement, pdpStatus, traceID, spanID)
-			writeRPCError(w, http.StatusBadGateway, req.ID, "upstream error", "UPSTREAM_ERROR", requestID)
+			writeRPCError(w, http.StatusBadGateway, req.ID, "upstream error", protocol.ErrorCodeUpstreamError, requestID)
 			return
 		}
 		defer toolRes.Body.Close()
@@ -518,11 +529,11 @@ func (h *mcpHandler) handleMCP(w http.ResponseWriter, r *http.Request) {
 	writeInvocationReceipt(ctx, logger, h.store, tenantID, decisionID, requestID, actor, mcpCtx, policyHash, policyVersion, outcome, intPtr(statusCode), pdpLatency, toolLatency, int(time.Since(started).Milliseconds()), meta, started, h.pepMode, enforcement, pdpStatus, traceID, spanID)
 
 	if err != nil {
-		writeRPCError(w, http.StatusServiceUnavailable, req.ID, "policy unavailable", "POLICY_UNAVAILABLE", requestID)
+		writeRPCError(w, http.StatusServiceUnavailable, req.ID, "policy unavailable", protocol.ErrorCodePolicyUnavailable, requestID)
 		return
 	}
 
-	writeRPCError(w, http.StatusForbidden, req.ID, "policy denied", "POLICY_DENIED", requestID, decision.DecisionID)
+	writeRPCError(w, http.StatusForbidden, req.ID, "policy denied", protocol.ErrorCodePolicyDenied, requestID, decision.DecisionID)
 }
 
 func buildForwardBody(req rpcRequest, params toolCallParams) ([]byte, error) {
@@ -621,12 +632,15 @@ func toolIdentifier(serverName, toolName string) string {
 }
 
 func writeRPCError(w http.ResponseWriter, status int, id json.RawMessage, message, code, requestID string, decisionID ...string) {
-	data := map[string]string{"error_code": code}
-	if requestID != "" {
-		data["request_id"] = requestID
+	if strings.TrimSpace(requestID) == "" {
+		requestID = uuid.NewString()
+	}
+	data := rpcErrorData{
+		Error:     rpcErrorBody{Code: code, Message: message},
+		RequestID: requestID,
 	}
 	if len(decisionID) > 0 && decisionID[0] != "" {
-		data["decision_id"] = decisionID[0]
+		data.DecisionID = decisionID[0]
 	}
 
 	resp := rpcResponse{
@@ -639,8 +653,21 @@ func writeRPCError(w http.ResponseWriter, status int, id json.RawMessage, messag
 		},
 	}
 	w.Header().Set("content-type", "application/json")
+	w.Header().Set("x-request-id", requestID)
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func writeRPCBadRequest(w http.ResponseWriter, id json.RawMessage, message, requestID string) {
+	writeRPCError(w, http.StatusBadRequest, id, message, protocol.ErrorCodeBadRequest, requestID)
+}
+
+func writeRPCMethodNotAllowed(w http.ResponseWriter) {
+	writeRPCError(w, http.StatusMethodNotAllowed, nil, "method not allowed", protocol.ErrorCodeMethodNotAllowed, "")
+}
+
+func writeRPCMethodNotSupported(w http.ResponseWriter, id json.RawMessage) {
+	writeRPCError(w, http.StatusBadRequest, id, "method not supported", protocol.ErrorCodeMethodNotSupported, "")
 }
 
 func durationFromEnv(key string, def time.Duration) time.Duration {

--- a/identity/control-plane/services/pdp/internal/http-api/contract_test.go
+++ b/identity/control-plane/services/pdp/internal/http-api/contract_test.go
@@ -78,11 +78,8 @@ func TestDecisionContractOpenAPI(t *testing.T) {
 	assertInSet(t, decisionEnum, "allow", "deny")
 
 	errResp := derefSchema(t, spec, spec.Components.Schemas["ErrorResponse"])
-	if errResp.Properties["error_code"] == nil {
-		t.Fatalf("missing error_code property in ErrorResponse")
-	}
-	if errResp.Properties["error_code"].Type != "" && errResp.Properties["error_code"].Type != "string" {
-		t.Fatalf("expected error_code to be string, got %q", errResp.Properties["error_code"].Type)
+	if errResp.Properties["error"] == nil {
+		t.Fatalf("missing error property in ErrorResponse")
 	}
 
 	op := spec.Paths["/v1/decision"].Post
@@ -146,8 +143,12 @@ func TestDecisionContractRuntime(t *testing.T) {
 	if err := json.NewDecoder(errRec.Body).Decode(&errOut); err != nil {
 		t.Fatalf("decode error response failed: %v", err)
 	}
-	if errOut["error_code"] != "POLICY_INVALID" {
-		t.Fatalf("expected error_code POLICY_INVALID, got %v", errOut["error_code"])
+	errObj, ok := errOut["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected error object, got %v", errOut["error"])
+	}
+	if errObj["code"] != "POLICY_INVALID" {
+		t.Fatalf("expected error code POLICY_INVALID, got %v", errObj["code"])
 	}
 }
 

--- a/identity/control-plane/services/pdp/internal/http-api/v0.go
+++ b/identity/control-plane/services/pdp/internal/http-api/v0.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -33,11 +34,15 @@ type receiptBody struct {
 	SpanID        string         `json:"span_id,omitempty"`
 }
 
+type errorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
 type errorResponse struct {
-	ErrorCode string `json:"error_code"`
-	Message   string `json:"message"`
-	RequestID string `json:"request_id,omitempty"`
-	TraceID   string `json:"trace_id,omitempty"`
+	Error     errorBody `json:"error"`
+	RequestID string    `json:"request_id,omitempty"`
+	TraceID   string    `json:"trace_id,omitempty"`
 }
 
 func registerV0(mux *http.ServeMux, logger *slog.Logger) {
@@ -55,7 +60,7 @@ func registerV0(mux *http.ServeMux, logger *slog.Logger) {
 
 	mux.HandleFunc("/v1/decision", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			w.WriteHeader(http.StatusMethodNotAllowed)
+			writeMethodNotAllowed(w)
 			return
 		}
 
@@ -66,7 +71,7 @@ func registerV0(mux *http.ServeMux, logger *slog.Logger) {
 		dec := json.NewDecoder(r.Body)
 		dec.DisallowUnknownFields()
 		if err := dec.Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "POLICY_INVALID", "invalid json", "", "")
+			writeError(w, http.StatusBadRequest, policy.ErrorCodePolicyInvalid, "invalid json", "", "")
 			return
 		}
 
@@ -83,7 +88,7 @@ func registerV0(mux *http.ServeMux, logger *slog.Logger) {
 
 		tenantID, err := uuid.Parse(req.Tenant.TenantID)
 		if err != nil || tenantID == uuid.Nil {
-			writeError(w, http.StatusBadRequest, "POLICY_INVALID", "invalid tenant_id", requestID, traceID)
+			writeError(w, http.StatusBadRequest, policy.ErrorCodePolicyInvalid, "invalid tenant_id", requestID, traceID)
 			return
 		}
 
@@ -132,7 +137,7 @@ func registerV0(mux *http.ServeMux, logger *slog.Logger) {
 
 		var pol policy.Policy
 		if err := json.Unmarshal(ap.Policy, &pol); err != nil {
-			writeError(w, http.StatusInternalServerError, "POLICY_INVALID", "invalid policy json", requestID, traceID)
+			writeError(w, http.StatusInternalServerError, policy.ErrorCodePolicyInvalid, "invalid policy json", requestID, traceID)
 			return
 		}
 
@@ -208,12 +213,19 @@ func writeJSON(w http.ResponseWriter, v interface{}) {
 }
 
 func writeError(w http.ResponseWriter, status int, code, message, requestID, traceID string) {
+	if strings.TrimSpace(requestID) == "" {
+		requestID = uuid.NewString()
+	}
 	w.Header().Set("content-type", "application/json")
+	w.Header().Set("x-request-id", requestID)
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(errorResponse{
-		ErrorCode: code,
-		Message:   message,
+		Error:     errorBody{Code: code, Message: message},
 		RequestID: requestID,
 		TraceID:   traceID,
 	})
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter) {
+	writeError(w, http.StatusMethodNotAllowed, protocol.ErrorCodeMethodNotAllowed, "method not allowed", "", "")
 }

--- a/identity/control-plane/services/pep-gateway/internal/http-api/v0.go
+++ b/identity/control-plane/services/pep-gateway/internal/http-api/v0.go
@@ -103,12 +103,44 @@ type invocationReceiptBody struct {
 	Enforcement   string            `json:"enforcement.outcome,omitempty"`
 }
 
+type errorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
 type blockedResponse struct {
-	ErrorCode  string `json:"error_code"`
-	Message    string `json:"message"`
-	RequestID  string `json:"request_id"`
-	DecisionID string `json:"decision_id,omitempty"`
-	TraceID    string `json:"trace_id,omitempty"`
+	Error      errorBody `json:"error"`
+	RequestID  string    `json:"request_id,omitempty"`
+	DecisionID string    `json:"decision_id,omitempty"`
+	TraceID    string    `json:"trace_id,omitempty"`
+}
+
+func writeErrorResponse(w http.ResponseWriter, status int, code, message, requestID, decisionID, traceID string) {
+	if strings.TrimSpace(requestID) == "" {
+		requestID = uuid.NewString()
+	}
+	resp := blockedResponse{
+		Error:      errorBody{Code: code, Message: message},
+		RequestID:  requestID,
+		DecisionID: decisionID,
+		TraceID:    traceID,
+	}
+	w.Header().Set("content-type", "application/json")
+	w.Header().Set("x-request-id", requestID)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter) {
+	writeErrorResponse(w, http.StatusMethodNotAllowed, protocol.ErrorCodeMethodNotAllowed, "method not allowed", "", "", "")
+}
+
+func writeInvalidJSON(w http.ResponseWriter) {
+	writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidJSON, "invalid json", "", "", "")
+}
+
+func writeInvalidTenant(w http.ResponseWriter) {
+	writeErrorResponse(w, http.StatusBadRequest, protocol.ErrorCodeInvalidTenant, "missing/invalid x-umbra-tenant-id", "", "", "")
 }
 
 func registerV0(mux *http.ServeMux, logger *slog.Logger) {
@@ -144,13 +176,13 @@ func registerV0(mux *http.ServeMux, logger *slog.Logger) {
 	// V0 convenience endpoint: POST /demo (JSON) to exercise the enforcement flow.
 	mux.HandleFunc("/demo", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			writeMethodNotAllowed(w)
 			return
 		}
 
 		var in demoInvokeRequest
 		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
-			http.Error(w, "invalid json", http.StatusBadRequest)
+			writeInvalidJSON(w)
 			return
 		}
 
@@ -180,7 +212,7 @@ func handleToolProxy(tracer trace.Tracer, logger *slog.Logger, store invocationS
 		tenantIDStr := r.Header.Get("x-umbra-tenant-id")
 		tenantID, err := uuid.Parse(tenantIDStr)
 		if err != nil || tenantID == uuid.Nil {
-			http.Error(w, "missing/invalid x-umbra-tenant-id", http.StatusBadRequest)
+			writeInvalidTenant(w)
 			return
 		}
 
@@ -280,7 +312,7 @@ func handleToolProxy(tracer trace.Tracer, logger *slog.Logger, store invocationS
 					reqLogger.Error("upstream error in observe mode (pdp unavailable)", "err", e)
 					writeInvocationReceipt(ctx, reqLogger, store, tenantID, nil, reqID, toolName, r.Method, upath, "", 0, "error", intPtr(http.StatusBadGateway), lat,
 						map[string]string{"stage": "pdp"}, "unavailable", pdpStatus, pdpErrorCode, started, pepMode, "forwarded")
-					http.Error(rw, "upstream error", http.StatusBadGateway)
+					writeErrorResponse(rw, http.StatusBadGateway, protocol.ErrorCodeUpstreamError, "upstream error", reqID, "", traceCtx.TraceID)
 				}
 				proxy.ServeHTTP(w, r)
 				return
@@ -289,15 +321,7 @@ func handleToolProxy(tracer trace.Tracer, logger *slog.Logger, store invocationS
 			lat := int(time.Since(started).Milliseconds())
 			writeInvocationReceipt(ctx, reqLogger, store, tenantID, nil, reqID, toolName, r.Method, upath, "", 0, "denied", intPtr(http.StatusServiceUnavailable), lat,
 				map[string]string{"stage": "pdp"}, "unavailable", pdpStatus, pdpErrorCode, started, pepMode, "blocked")
-			w.Header().Set("content-type", "application/json")
-			w.WriteHeader(http.StatusServiceUnavailable)
-			resp := blockedResponse{
-				ErrorCode: "POLICY_UNAVAILABLE",
-				Message:   "pdp unavailable",
-				RequestID: reqID,
-				TraceID:   traceCtx.TraceID,
-			}
-			_ = json.NewEncoder(w).Encode(resp)
+			writeErrorResponse(w, http.StatusServiceUnavailable, protocol.ErrorCodePolicyUnavailable, "pdp unavailable", reqID, "", traceCtx.TraceID)
 			return
 		}
 
@@ -323,7 +347,7 @@ func handleToolProxy(tracer trace.Tracer, logger *slog.Logger, store invocationS
 					reqLogger.Error("upstream error in observe mode", "err", e)
 					writeInvocationReceipt(ctx, reqLogger, store, tenantID, &decisionID, reqID, toolName, r.Method, upath, decision.PolicyHash, decision.PolicyVersion, "denied", intPtr(http.StatusBadGateway), lat,
 						map[string]string{"reason": decision.Reason}, decision.Decision, "ok", "", started, pepMode, "forwarded")
-					http.Error(rw, "upstream error", http.StatusBadGateway)
+					writeErrorResponse(rw, http.StatusBadGateway, protocol.ErrorCodeUpstreamError, "upstream error", reqID, decision.DecisionID, traceCtx.TraceID)
 				}
 				proxy.ServeHTTP(w, r)
 				return
@@ -335,16 +359,7 @@ func handleToolProxy(tracer trace.Tracer, logger *slog.Logger, store invocationS
 					map[string]string{"reason": decision.Reason}, decision.Decision, "ok", "", started, pepMode, "blocked")
 
 				// Return structured error response
-				w.Header().Set("content-type", "application/json")
-				w.WriteHeader(http.StatusForbidden)
-				resp := blockedResponse{
-					ErrorCode:  "POLICY_DENIED",
-					Message:    decision.Reason,
-					RequestID:  reqID,
-					DecisionID: decision.DecisionID,
-					TraceID:    traceCtx.TraceID,
-				}
-				_ = json.NewEncoder(w).Encode(resp)
+				writeErrorResponse(w, http.StatusForbidden, protocol.ErrorCodePolicyDenied, decision.Reason, reqID, decision.DecisionID, traceCtx.TraceID)
 				return
 			}
 		}
@@ -363,7 +378,7 @@ func handleToolProxy(tracer trace.Tracer, logger *slog.Logger, store invocationS
 			reqLogger.Error("upstream error", "err", e)
 			writeInvocationReceipt(ctx, reqLogger, store, tenantID, &decisionID, reqID, toolName, r.Method, upath, decision.PolicyHash, decision.PolicyVersion, "error", intPtr(http.StatusBadGateway), lat,
 				map[string]string{"upstream": proxyURLHost(proxy)}, decision.Decision, "ok", "", started, pepMode, "forwarded")
-			http.Error(rw, "upstream error", http.StatusBadGateway)
+			writeErrorResponse(rw, http.StatusBadGateway, protocol.ErrorCodeUpstreamError, "upstream error", reqID, decision.DecisionID, traceCtx.TraceID)
 		}
 
 		proxy.ServeHTTP(w, r)
@@ -445,12 +460,12 @@ func classifyPDPError(err error, status int) (string, string) {
 		return "ok", ""
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
-		return "timeout", "POLICY_UNAVAILABLE"
+		return "timeout", protocol.ErrorCodePolicyUnavailable
 	}
 	if status >= 500 || status == 0 {
-		return "unavailable", "POLICY_UNAVAILABLE"
+		return "unavailable", protocol.ErrorCodePolicyUnavailable
 	}
-	return "error", "POLICY_UNAVAILABLE"
+	return "error", protocol.ErrorCodePolicyUnavailable
 }
 
 func getenv(k, d string) string {

--- a/identity/control-plane/services/pep-gateway/internal/http-api/v0_test.go
+++ b/identity/control-plane/services/pep-gateway/internal/http-api/v0_test.go
@@ -92,8 +92,11 @@ func TestObserveVsEnforceMode(t *testing.T) {
 			if tt.pepMode == "enforce" && tt.decision == "deny" {
 				var errResp blockedResponse
 				json.NewDecoder(rec.Body).Decode(&errResp)
-				if errResp.ErrorCode != "POLICY_DENIED" {
-					t.Errorf("expected error code POLICY_DENIED, got %s", errResp.ErrorCode)
+				if errResp.Error.Code == "" || errResp.Error.Message == "" {
+					t.Error("expected error code and message in response")
+				}
+				if errResp.Error.Code != "POLICY_DENIED" {
+					t.Errorf("expected error code POLICY_DENIED, got %s", errResp.Error.Code)
 				}
 				if errResp.RequestID == "" {
 					t.Error("expected request_id in error response")
@@ -179,6 +182,9 @@ func TestInvocationCorrelationIDs(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&errResp); err != nil {
 		t.Fatalf("decode response failed: %v", err)
 	}
+	if errResp.Error.Code == "" || errResp.Error.Message == "" {
+		t.Fatal("expected error code and message in response")
+	}
 	if errResp.RequestID == "" {
 		t.Fatal("expected request_id in response")
 	}
@@ -255,8 +261,8 @@ func TestPDPUnavailableObserveVsEnforce(t *testing.T) {
 				if err := json.NewDecoder(rec.Body).Decode(&errResp); err != nil {
 					t.Fatalf("decode response failed: %v", err)
 				}
-				if errResp.ErrorCode != tt.expectedCode {
-					t.Fatalf("expected error code %s, got %s", tt.expectedCode, errResp.ErrorCode)
+				if errResp.Error.Code != tt.expectedCode {
+					t.Fatalf("expected error code %s, got %s", tt.expectedCode, errResp.Error.Code)
 				}
 			}
 		})

--- a/identity/control-plane/ui/contracts/openapi.ts
+++ b/identity/control-plane/ui/contracts/openapi.ts
@@ -54,17 +54,17 @@ export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
     ErrorResponse: {
-      /** @description Stable error identifier (service-specific until error-envelope work is complete). */
-      error_code: string;
-      message: string;
+      error: {
+        code: string;
+        message: string;
+        details?: {
+            field?: string;
+            message?: string;
+          }[];
+      };
       request_id?: string;
       decision_id?: string;
       trace_id?: string;
-      /** @description Optional field-level validation issues. */
-      errors?: {
-          field?: string;
-          message?: string;
-        }[];
     };
     TenantContext: {
       tenant_id: string;

--- a/identity/control-plane/ui/contracts/openapi.ts
+++ b/identity/control-plane/ui/contracts/openapi.ts
@@ -55,8 +55,10 @@ export interface components {
   schemas: {
     ErrorResponse: {
       error: {
+        /** @description Stable error identifier. */
         code: string;
         message: string;
+        /** @description Optional field-level validation issues. */
         details?: {
             field?: string;
             message?: string;


### PR DESCRIPTION
Resolves:
-  UMBRA‑0024: Error Envelope Consistency, https://github.com/srehcs/umbra/issues/32

 Summary:
- Standardize error envelopes across controlplane‑api, pdp, pep‑gateway, and mcp‑adapter.
- Always generate and return request_id for error responses.
- Centralize error codes in protocol and add JSON‑RPC error mapping doc.
- Update OpenAPI + generated TS contracts; fix runbook wording.

Testing:
- go test ./services/controlplane-api/internal/http-api ./services/pdp/internal/http-api ./services/pep-gateway/internal/http-api ./services/mcp-adapter/internal/http-api

Notes:
- New docs: error_envelope.md
