### PR TITLE
Feature: Idempotency Replay Protection And Canonical Receipt Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ git.config
 
 # Go
 .gocache/
+.cache/
 
 # Node/pnpm
 .pnpm/

--- a/identity/control-plane/docs/02_where_we_are_now.md
+++ b/identity/control-plane/docs/02_where_we_are_now.md
@@ -17,6 +17,7 @@ This document is a reality check: **what is implemented in this repo** vs **what
 - **MCP adapter**:
   - intercepts MCP tool calls (`tools/call`) and converts to PDP requests
   - enforces allow/deny and emits invocation receipts
+- **Receipt idempotency**: request_id dedupe window for receipt ingest and internal receipt writers.
 - **UI (Next.js + ShadCN)**:
   - tools
   - policies (author + activate)

--- a/identity/control-plane/docs/README.md
+++ b/identity/control-plane/docs/README.md
@@ -30,6 +30,8 @@
 
 ## Receipts integrity
 - `receipts_integrity.md`
+- `receipts_canonicalization.md`
+- `idempotency.md`
 
 ## Navigation
 - `repo_map.md`

--- a/identity/control-plane/docs/api/openapi.yaml
+++ b/identity/control-plane/docs/api/openapi.yaml
@@ -369,6 +369,12 @@ paths:
             schema:
               $ref: '#/components/schemas/ReceiptIngestRequest'
       responses:
+        '200':
+          description: Idempotent replay (existing receipt)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReceiptIngestResponse'
         '201':
           description: Created
           content:
@@ -377,6 +383,15 @@ paths:
                 $ref: '#/components/schemas/ReceiptIngestResponse'
         '400':
           description: Invalid request
+          headers:
+            x-umbra-request-id:
+              $ref: '#/components/headers/RequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Request ID conflict
           headers:
             x-umbra-request-id:
               $ref: '#/components/headers/RequestId'
@@ -796,7 +811,9 @@ components:
       type: object
       properties:
         kind: { type: string, enum: [decision, invocation] }
-        request_id: { type: string }
+        request_id:
+          type: string
+          description: Idempotency key for receipt ingest (tenant-scoped).
         decision_id: { type: string }
         trace_id: { type: string }
         span_id: { type: string }

--- a/identity/control-plane/docs/how-to-develop.md
+++ b/identity/control-plane/docs/how-to-develop.md
@@ -61,6 +61,12 @@ curl -s \
   http://localhost:3000/api/auth/session | jq .
 ```
 
+Receipt idempotency config
+```bash
+export UMBRA_REQUEST_ID_DEDUPE_WINDOW="24h"
+export UMBRA_RECEIPT_CHAIN_LOCK_SCOPE="tenant" # or "day"
+```
+
 E2E smoke tests
 ```bash
 make e2e

--- a/identity/control-plane/docs/idempotency.md
+++ b/identity/control-plane/docs/idempotency.md
@@ -1,0 +1,46 @@
+# Idempotency + Replay Protection (V0)
+
+This document defines how Umbra uses `request_id` to provide idempotency for
+receipt ingestion and internal receipt writes.
+
+## Summary
+- Receipt ingest replays return the original receipt and do not duplicate rows.
+- Conflicting replays return `409 CONFLICT` with error code `CONFLICT`.
+- Internal receipt writers dedupe within the configured window.
+- Idempotency and receipt chains are serialized with transactional advisory locks per tenant/kind.
+
+## Scope
+- Receipt ingest (`POST /v1/receipts`) uses `request_id` as the idempotency key.
+- PDP/PEP/MCP receipt writers dedupe on `request_id` to avoid duplicate receipts.
+- This does **not** guarantee idempotency of upstream tool executions; clients
+  must handle tool-level idempotency separately.
+
+## Dedupe window
+- Default window: 24h.
+- Configurable via `UMBRA_REQUEST_ID_DEDUPE_WINDOW` (Go duration string, e.g. `24h`).
+- After the window expires, the same `request_id` may be accepted as new.
+
+## Chain lock scope
+- Default scope: `tenant` (single chain per tenant/kind).
+- Optional: set `UMBRA_RECEIPT_CHAIN_LOCK_SCOPE=day` to partition by UTC day.
+- Partitioning improves write throughput but yields per-day chains.
+
+## Receipt ingest behavior
+- `request_id` is required in the request body.
+- Replay with same `request_id` **and** identical canonical body:
+  - returns `200 OK` with the original `receipt_id`/hash.
+  - does not create a new receipt row.
+- Replay with same `request_id` but different body:
+  - returns `409 CONFLICT` with error code `CONFLICT`.
+- Matching considers stored receipt fields plus the canonical body.
+- Trace/span and latency/status fields are excluded from idempotency matching.
+
+## Internal receipt writers (PDP/PEP/MCP)
+- Same-window replays with identical canonical body are skipped.
+- Conflicts are logged and skipped.
+
+## Client retry rules
+- Retries for the same logical action should reuse the same `request_id`.
+- New actions must use a new `request_id`.
+- For tool-level idempotency, use application-specific idempotency keys or
+  server-side dedupe in the upstream service.

--- a/identity/control-plane/docs/receipts_canonicalization.md
+++ b/identity/control-plane/docs/receipts_canonicalization.md
@@ -1,10 +1,12 @@
 # Receipt Canonicalization (V0)
 
 Deterministic hashing depends on stable byte serialization. In V0 we use Go's
-`encoding/json` marshaling on structs to produce canonical JSON bytes.
+`encoding/json` marshaling on structs to produce canonical JSON bytes. For
+receipt ingest, raw JSON is canonicalized by sorting object keys.
 
 ## Rules
-- Canonicalization uses Go structs with explicit field order; maps are forbidden.
+- Internal receipts use Go structs with explicit field order; maps are forbidden.
+- Receipt ingest canonicalizes raw JSON by sorting object keys.
 - Do not use floats in receipt bodies (avoid 1 vs 1.0 ambiguity).
 - Use `omitempty` for optional fields; zero values must be omitted.
 - Arrays preserve order; do not reorder elements for hashing.

--- a/identity/control-plane/docs/test_vectors/canonicalization/README.md
+++ b/identity/control-plane/docs/test_vectors/canonicalization/README.md
@@ -11,4 +11,8 @@ How to use:
 2. Serialize to canonical JSON bytes (no whitespace).
 3. Compare the bytes to `canonical` and hash to `hash`.
 
+Notes:
+- Receipt ingest canonicalizes raw JSON by sorting object keys before hashing.
+- Floats and non-ASCII strings/keys are invalid for V0 receipt bodies.
+
 If your implementation produces different bytes, receipt hashes will diverge.

--- a/identity/control-plane/packages/contracts/openapi.ts
+++ b/identity/control-plane/packages/contracts/openapi.ts
@@ -253,6 +253,7 @@ export interface components {
     ReceiptIngestBase: {
       /** @enum {string} */
       kind: "decision" | "invocation";
+      /** @description Idempotency key for receipt ingest (tenant-scoped). */
       request_id: string;
       decision_id?: string;
       trace_id?: string;
@@ -636,6 +637,12 @@ export interface operations {
       };
     };
     responses: {
+      /** @description Idempotent replay (existing receipt) */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ReceiptIngestResponse"];
+        };
+      };
       /** @description Created */
       201: {
         content: {
@@ -644,6 +651,15 @@ export interface operations {
       };
       /** @description Invalid request */
       400: {
+        headers: {
+          "x-umbra-request-id": components["headers"]["RequestId"];
+        };
+        content: {
+          "application/json": components["schemas"]["ErrorResponse"];
+        };
+      };
+      /** @description Request ID conflict */
+      409: {
         headers: {
           "x-umbra-request-id": components["headers"]["RequestId"];
         };

--- a/identity/control-plane/packages/go/receipts/canonical_json_bytes_test.go
+++ b/identity/control-plane/packages/go/receipts/canonical_json_bytes_test.go
@@ -1,0 +1,29 @@
+package receipts
+
+import "testing"
+
+func TestCanonicalJSONBytes_SortsKeys(t *testing.T) {
+	raw := []byte(`{"b":1,"a":{"d":4,"c":3},"arr":[{"z":2,"y":1},2]}`)
+	out, err := CanonicalJSONBytes(raw)
+	if err != nil {
+		t.Fatalf("canonicalize raw: %v", err)
+	}
+	expected := `{"a":{"c":3,"d":4},"arr":[{"y":1,"z":2},2],"b":1}`
+	if string(out) != expected {
+		t.Fatalf("canonical mismatch\nexpected: %s\ngot:      %s", expected, string(out))
+	}
+}
+
+func TestCanonicalJSONBytes_RejectsFloats(t *testing.T) {
+	_, err := CanonicalJSONBytes([]byte(`{"a":1.25}`))
+	if err == nil {
+		t.Fatalf("expected float rejection")
+	}
+}
+
+func TestCanonicalJSONBytes_RejectsNonASCII(t *testing.T) {
+	_, err := CanonicalJSONBytes([]byte(`{"a":"caf\u00e9"}`))
+	if err == nil {
+		t.Fatalf("expected non-ascii rejection")
+	}
+}

--- a/identity/control-plane/packages/go/receipts/idempotency.go
+++ b/identity/control-plane/packages/go/receipts/idempotency.go
@@ -1,0 +1,111 @@
+package receipts
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"strings"
+	"time"
+)
+
+// IdempotencyOutcome represents the result of an idempotent insert attempt.
+type IdempotencyOutcome int
+
+const (
+	IdempotencyInserted IdempotencyOutcome = iota
+	IdempotencyReplayed
+	IdempotencyConflict
+)
+
+// DefaultRequestIDDedupeWindow is the default idempotency window for request_id.
+const DefaultRequestIDDedupeWindow = 24 * time.Hour
+
+// ParseRequestIDDedupeWindow parses a duration string for request_id dedupe windows.
+func ParseRequestIDDedupeWindow(raw string) (time.Duration, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return 0, fmt.Errorf("request_id dedupe window is empty")
+	}
+	window, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("request_id dedupe window invalid: %w", err)
+	}
+	if window <= 0 {
+		return 0, fmt.Errorf("request_id dedupe window must be positive")
+	}
+	return window, nil
+}
+
+// RequestIDDedupeSince returns the cutoff timestamp for idempotency checks.
+func RequestIDDedupeSince(now time.Time, window time.Duration) time.Time {
+	return now.Add(-window)
+}
+
+// IdempotencyPayload captures the persisted fields used for idempotency matching.
+type IdempotencyPayload struct {
+	Kind       string          `json:"kind"`
+	RequestID  string          `json:"request_id"`
+	DecisionID string          `json:"decision_id,omitempty"`
+	Decision   string          `json:"decision,omitempty"`
+	PolicyHash string          `json:"policy_hash,omitempty"`
+	ToolName   string          `json:"tool_name,omitempty"`
+	Method     string          `json:"method,omitempty"`
+	Path       string          `json:"path,omitempty"`
+	Outcome    string          `json:"outcome,omitempty"`
+	Body       json.RawMessage `json:"body"`
+}
+
+// CanonicalizeIdempotencyPayload returns canonical JSON for idempotency matching.
+func CanonicalizeIdempotencyPayload(payload IdempotencyPayload) ([]byte, error) {
+	return CanonicalJSON(payload)
+}
+
+// AdvisoryLockPair returns a stable pair of 32-bit keys for advisory locks.
+func AdvisoryLockPair(tenantID string, kind string, requestID string) (int32, int32) {
+	return hash32(tenantID, kind), hash32(requestID)
+}
+
+// ResolveRequestIDDedupeWindow returns the configured window or the default.
+func ResolveRequestIDDedupeWindow(raw string) (time.Duration, error) {
+	if strings.TrimSpace(raw) == "" {
+		return DefaultRequestIDDedupeWindow, nil
+	}
+	window, err := ParseRequestIDDedupeWindow(raw)
+	if err != nil {
+		return DefaultRequestIDDedupeWindow, err
+	}
+	return window, nil
+}
+
+// ResolveChainLockScope validates the chain lock scope.
+func ResolveChainLockScope(raw string) (string, error) {
+	value := strings.TrimSpace(strings.ToLower(raw))
+	if value == "" {
+		return "tenant", nil
+	}
+	switch value {
+	case "tenant", "day":
+		return value, nil
+	default:
+		return "tenant", fmt.Errorf("invalid chain lock scope: %s", value)
+	}
+}
+
+// ChainLockPair returns the advisory lock keys for chain serialization.
+func ChainLockPair(tenantID string, kind string, now time.Time, scope string) (int32, int32) {
+	switch scope {
+	case "day":
+		return AdvisoryLockPair(tenantID, kind, "chain:"+now.UTC().Format("2006-01-02"))
+	default:
+		return AdvisoryLockPair(tenantID, kind, "chain")
+	}
+}
+
+func hash32(parts ...string) int32 {
+	h := fnv.New32a()
+	for _, part := range parts {
+		_, _ = h.Write([]byte(part))
+		_, _ = h.Write([]byte{0})
+	}
+	return int32(h.Sum32())
+}

--- a/identity/control-plane/packages/go/receipts/receipts.go
+++ b/identity/control-plane/packages/go/receipts/receipts.go
@@ -1,9 +1,14 @@
 package receipts
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"io"
+	"sort"
+	"strings"
 )
 
 // IMPORTANT: Determinism matters.
@@ -53,6 +58,131 @@ type VerifyResult struct {
 func CanonicalJSON(v interface{}) ([]byte, error) {
 	// Only deterministic if v is a struct / stable slices.
 	return json.Marshal(v)
+}
+
+var (
+	ErrCanonicalJSONNonASCII    = errors.New("canonical json contains non-ascii")
+	ErrCanonicalJSONFloat       = errors.New("canonical json contains float")
+	ErrCanonicalJSONTrailing    = errors.New("canonical json has trailing data")
+	ErrCanonicalJSONUnsupported = errors.New("canonical json has unsupported type")
+)
+
+// CanonicalJSONBytes canonicalizes raw JSON by sorting object keys and
+// preserving numeric string values from json.Number.
+func CanonicalJSONBytes(raw []byte) ([]byte, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value interface{}
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	if err := ensureDecoderEOF(decoder); err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := encodeCanonicalJSON(&buf, value); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func ensureDecoderEOF(decoder *json.Decoder) error {
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return ErrCanonicalJSONTrailing
+		}
+		return err
+	}
+	return nil
+}
+
+func encodeCanonicalJSON(buf *bytes.Buffer, value interface{}) error {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			if !isASCII(key) {
+				return ErrCanonicalJSONNonASCII
+			}
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		buf.WriteByte('{')
+		for i, key := range keys {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := writeJSONString(buf, key); err != nil {
+				return err
+			}
+			buf.WriteByte(':')
+			if err := encodeCanonicalJSON(buf, v[key]); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte('}')
+	case []interface{}:
+		buf.WriteByte('[')
+		for i, item := range v {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := encodeCanonicalJSON(buf, item); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(']')
+	case string:
+		if !isASCII(v) {
+			return ErrCanonicalJSONNonASCII
+		}
+		if err := writeJSONString(buf, v); err != nil {
+			return err
+		}
+	case json.Number:
+		if err := validateJSONNumber(v); err != nil {
+			return err
+		}
+		buf.WriteString(v.String())
+	case bool:
+		if v {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+	case nil:
+		buf.WriteString("null")
+	default:
+		return ErrCanonicalJSONUnsupported
+	}
+	return nil
+}
+
+func writeJSONString(buf *bytes.Buffer, value string) error {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	buf.Write(encoded)
+	return nil
+}
+
+func validateJSONNumber(value json.Number) error {
+	raw := value.String()
+	if strings.ContainsAny(raw, ".eE") {
+		return ErrCanonicalJSONFloat
+	}
+	return nil
+}
+
+func isASCII(value string) bool {
+	for i := 0; i < len(value); i++ {
+		if value[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }
 
 func HashBytes(b []byte) string {

--- a/identity/control-plane/packages/go/storage/locks.go
+++ b/identity/control-plane/packages/go/storage/locks.go
@@ -1,0 +1,13 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// AdvisoryLockTx acquires a transaction-scoped advisory lock.
+func AdvisoryLockTx(ctx context.Context, tx pgx.Tx, key1, key2 int32) error {
+	_, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1, $2)`, key1, key2)
+	return err
+}

--- a/identity/control-plane/services/controlplane-api/internal/http-api/integration_test.go
+++ b/identity/control-plane/services/controlplane-api/internal/http-api/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/umbra-labs/agent-identity-control-plane/packages/go/policy"
+	"github.com/umbra-labs/agent-identity-control-plane/packages/go/protocol"
 	"github.com/umbra-labs/agent-identity-control-plane/packages/go/testutil"
 	"github.com/umbra-labs/agent-identity-control-plane/services/controlplane-api/internal/storage"
 )
@@ -222,6 +224,264 @@ func TestReceiptIngestDecisionChain(t *testing.T) {
 	}
 }
 
+func TestReceiptIngestIdempotency(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("UMBRA_TEST_DATABASE_URL"))
+	if dsn == "" {
+		t.Skip("UMBRA_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	db, cleanup := testutil.ConnectIsolatedTestDB(t, dsn)
+	defer cleanup()
+
+	if err := applySchema(t, db.Pool); err != nil {
+		t.Fatalf("schema setup failed: %v", err)
+	}
+
+	tenantID := createTenant(t, db.Pool, "receipt-idem-tenant")
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	server := &Server{Logger: logger, Store: storage.New(db)}
+
+	body := map[string]interface{}{
+		"actor": map[string]interface{}{"id": "user-1", "type": "human"},
+		"tool":  map[string]interface{}{"name": "demo.tool", "method": "GET", "endpoint": "/demo"},
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	base := receiptIngestRequest{
+		Kind:       "decision",
+		RequestID:  "req-idem-1",
+		DecisionID: uuid.NewString(),
+		Decision:   "allow",
+		PolicyHash: "policy-hash-1",
+		Body:       bodyBytes,
+	}
+
+	first := ingestReceiptRaw(t, server, tenantID, base)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("receipt ingest failed: %d %s", first.Code, first.Body.String())
+	}
+	var firstResp receiptIngestResponse
+	if err := json.Unmarshal(first.Body.Bytes(), &firstResp); err != nil {
+		t.Fatalf("parse receipt ingest response: %v", err)
+	}
+
+	second := ingestReceiptRaw(t, server, tenantID, base)
+	if second.Code != http.StatusOK {
+		t.Fatalf("expected idempotent replay, got %d %s", second.Code, second.Body.String())
+	}
+	var secondResp receiptIngestResponse
+	if err := json.Unmarshal(second.Body.Bytes(), &secondResp); err != nil {
+		t.Fatalf("parse replay response: %v", err)
+	}
+	if secondResp.ReceiptID != firstResp.ReceiptID || secondResp.Hash != firstResp.Hash {
+		t.Fatalf("expected replay to return original receipt")
+	}
+
+	var count int
+	if err := db.Pool.QueryRow(ctx, `
+    SELECT COUNT(*)
+    FROM receipts_decision
+    WHERE tenant_id=$1 AND request_id=$2`, tenantID, base.RequestID).Scan(&count); err != nil {
+		t.Fatalf("count receipts failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 receipt, got %d", count)
+	}
+
+	conflict := base
+	conflict.Decision = "deny"
+	third := ingestReceiptRaw(t, server, tenantID, conflict)
+	if third.Code != http.StatusConflict {
+		t.Fatalf("expected conflict, got %d %s", third.Code, third.Body.String())
+	}
+	var errResp protocol.ErrorResponse
+	if err := json.Unmarshal(third.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("parse conflict response: %v", err)
+	}
+	if errResp.Error.Code != protocol.ErrorCodeConflict {
+		t.Fatalf("expected conflict error code, got %s", errResp.Error.Code)
+	}
+}
+
+func TestReceiptIngestIdempotencyCanonicalBody(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("UMBRA_TEST_DATABASE_URL"))
+	if dsn == "" {
+		t.Skip("UMBRA_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	db, cleanup := testutil.ConnectIsolatedTestDB(t, dsn)
+	defer cleanup()
+
+	if err := applySchema(t, db.Pool); err != nil {
+		t.Fatalf("schema setup failed: %v", err)
+	}
+
+	tenantID := createTenant(t, db.Pool, "receipt-idem-canonical")
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	server := &Server{Logger: logger, Store: storage.New(db)}
+
+	bodyA := json.RawMessage(`{"b":2,"a":{"d":4,"c":3}}`)
+	bodyB := json.RawMessage(`{"a":{"c":3,"d":4},"b":2}`)
+
+	base := receiptIngestRequest{
+		Kind:      "invocation",
+		RequestID: "req-idem-canonical-1",
+		ToolName:  "demo.tool",
+		Method:    "GET",
+		Path:      "/demo",
+		Outcome:   "success",
+		LatencyMs: intPtr(12),
+		Body:      bodyA,
+	}
+
+	first := ingestReceiptRaw(t, server, tenantID, base)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("receipt ingest failed: %d %s", first.Code, first.Body.String())
+	}
+	var firstResp receiptIngestResponse
+	if err := json.Unmarshal(first.Body.Bytes(), &firstResp); err != nil {
+		t.Fatalf("parse receipt ingest response: %v", err)
+	}
+
+	replay := base
+	replay.Body = bodyB
+	second := ingestReceiptRaw(t, server, tenantID, replay)
+	if second.Code != http.StatusOK {
+		t.Fatalf("expected idempotent replay, got %d %s", second.Code, second.Body.String())
+	}
+	var secondResp receiptIngestResponse
+	if err := json.Unmarshal(second.Body.Bytes(), &secondResp); err != nil {
+		t.Fatalf("parse replay response: %v", err)
+	}
+	if secondResp.ReceiptID != firstResp.ReceiptID || secondResp.Hash != firstResp.Hash {
+		t.Fatalf("expected replay to return original receipt")
+	}
+
+	var count int
+	if err := db.Pool.QueryRow(ctx, `
+    SELECT COUNT(*)
+    FROM receipts_invocation
+    WHERE tenant_id=$1 AND request_id=$2`, tenantID, base.RequestID).Scan(&count); err != nil {
+		t.Fatalf("count receipts failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 receipt, got %d", count)
+	}
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func TestReceiptIngestIdempotencyConcurrent(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("UMBRA_TEST_DATABASE_URL"))
+	if dsn == "" {
+		t.Skip("UMBRA_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	db, cleanup := testutil.ConnectIsolatedTestDB(t, dsn)
+	defer cleanup()
+
+	if err := applySchema(t, db.Pool); err != nil {
+		t.Fatalf("schema setup failed: %v", err)
+	}
+
+	tenantID := createTenant(t, db.Pool, "receipt-idem-concurrent")
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	server := &Server{Logger: logger, Store: storage.New(db)}
+
+	reqBody := json.RawMessage(`{"actor":{"id":"user-1","type":"human"}}`)
+	base := receiptIngestRequest{
+		Kind:       "decision",
+		RequestID:  "req-idem-concurrent-1",
+		DecisionID: uuid.NewString(),
+		Decision:   "allow",
+		PolicyHash: "policy-hash-1",
+		Body:       reqBody,
+	}
+	bodyBytes, _ := json.Marshal(base)
+
+	start := make(chan struct{})
+	results := make(chan *httptest.ResponseRecorder, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			results <- ingestReceiptRawBytes(server, tenantID, bodyBytes)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	statuses := map[int]int{}
+	for resp := range results {
+		statuses[resp.Code]++
+	}
+	if statuses[http.StatusCreated] != 1 || statuses[http.StatusOK] != 1 {
+		t.Fatalf("expected one created and one replay, got %+v", statuses)
+	}
+
+	var count int
+	if err := db.Pool.QueryRow(ctx, `
+    SELECT COUNT(*)
+    FROM receipts_decision
+    WHERE tenant_id=$1 AND request_id=$2`, tenantID, base.RequestID).Scan(&count); err != nil {
+		t.Fatalf("count receipts failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 receipt, got %d", count)
+	}
+}
+
+func TestReceiptIngestRejectsInvalidJSONNumbers(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("UMBRA_TEST_DATABASE_URL"))
+	if dsn == "" {
+		t.Skip("UMBRA_TEST_DATABASE_URL not set")
+	}
+	db, cleanup := testutil.ConnectIsolatedTestDB(t, dsn)
+	defer cleanup()
+
+	if err := applySchema(t, db.Pool); err != nil {
+		t.Fatalf("schema setup failed: %v", err)
+	}
+
+	tenantID := createTenant(t, db.Pool, "receipt-invalid-json")
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	server := &Server{Logger: logger, Store: storage.New(db)}
+
+	base := receiptIngestRequest{
+		Kind:       "decision",
+		RequestID:  "req-invalid-json-1",
+		DecisionID: uuid.NewString(),
+		Decision:   "allow",
+		PolicyHash: "policy-hash-1",
+	}
+
+	cases := []struct {
+		name string
+		body json.RawMessage
+	}{
+		{name: "float", body: json.RawMessage(`{"latency_ms":1.25}`)},
+		{name: "non_ascii", body: json.RawMessage(`{"msg":"caf\u00e9"}`)},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			req := base
+			req.RequestID = base.RequestID + "-" + tc.name
+			req.Body = tc.body
+			resp := ingestReceiptRaw(t, server, tenantID, req)
+			if resp.Code != http.StatusBadRequest {
+				t.Fatalf("expected bad request, got %d %s", resp.Code, resp.Body.String())
+			}
+		})
+	}
+}
+
 func applySchema(t *testing.T, pool *pgxpool.Pool) error {
 	t.Helper()
 	return testutil.ApplySchemaForTests(t, pool)
@@ -327,11 +587,7 @@ func listPoliciesViaAPI(t *testing.T, server *Server, tenant uuid.UUID) []policy
 
 func ingestReceipt(t *testing.T, server *Server, tenant uuid.UUID, body receiptIngestRequest) receiptIngestResponse {
 	t.Helper()
-	bodyBytes, _ := json.Marshal(body)
-	req := httptest.NewRequest("POST", "/v1/receipts", bytes.NewReader(bodyBytes))
-	req.Header.Set("x-umbra-tenant-id", tenant.String())
-	w := httptest.NewRecorder()
-	server.handleReceipts(w, req)
+	w := ingestReceiptRaw(t, server, tenant, body)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("receipt ingest failed: %d %s", w.Code, w.Body.String())
 	}
@@ -340,4 +596,18 @@ func ingestReceipt(t *testing.T, server *Server, tenant uuid.UUID, body receiptI
 		t.Fatalf("parse receipt ingest response: %v", err)
 	}
 	return out
+}
+
+func ingestReceiptRaw(t *testing.T, server *Server, tenant uuid.UUID, body receiptIngestRequest) *httptest.ResponseRecorder {
+	t.Helper()
+	bodyBytes, _ := json.Marshal(body)
+	return ingestReceiptRawBytes(server, tenant, bodyBytes)
+}
+
+func ingestReceiptRawBytes(server *Server, tenant uuid.UUID, body []byte) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("POST", "/v1/receipts", bytes.NewReader(body))
+	req.Header.Set("x-umbra-tenant-id", tenant.String())
+	w := httptest.NewRecorder()
+	server.handleReceipts(w, req)
+	return w
 }

--- a/identity/control-plane/services/controlplane-api/internal/http-api/v0.go
+++ b/identity/control-plane/services/controlplane-api/internal/http-api/v0.go
@@ -1,7 +1,6 @@
 package httpapi
 
 import (
-	"bytes"
 	"context"
 	"encoding/csv"
 	"encoding/json"
@@ -11,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/umbra-labs/agent-identity-control-plane/packages/go/policy"
@@ -84,6 +84,8 @@ type receiptIngestResponse struct {
 	Hash      string `json:"hash"`
 	PrevHash  string `json:"prev_hash,omitempty"`
 }
+
+const requestIDConflictMessage = "request_id conflicts with existing receipt"
 
 func registerV0(mux *http.ServeMux, logger *slog.Logger) {
 	// Wire DB (V0 simple): create store per request via global singleton in closure.
@@ -627,12 +629,19 @@ func (s *Server) handleReceiptsIngest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var compact bytes.Buffer
-	if err := json.Compact(&compact, body.Body); err != nil {
+	canonicalBytes, err := receipts.CanonicalJSONBytes(body.Body)
+	if err != nil {
+		writeErrorResponse(w, http.StatusBadRequest, "RECEIPT_INVALID", receiptCanonicalizationError(err), nil, r)
+		return
+	}
+	idempotencyBytes, err := canonicalizeIdempotencyPayload(body, canonicalBytes)
+	if err != nil {
 		writeErrorResponse(w, http.StatusBadRequest, "RECEIPT_INVALID", "receipt body must be valid JSON", nil, r)
 		return
 	}
-	compactBody := json.RawMessage(compact.Bytes())
+	canonicalBody := json.RawMessage(canonicalBytes)
+	idempotencyBody := json.RawMessage(idempotencyBytes)
+	dedupeSince := receipts.RequestIDDedupeSince(time.Now().UTC(), requestIDDedupeWindow(s.Logger))
 
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 	defer cancel()
@@ -644,19 +653,22 @@ func (s *Server) handleReceiptsIngest(w http.ResponseWriter, r *http.Request) {
 			writeErrorResponse(w, http.StatusBadRequest, "RECEIPT_INVALID", "invalid decision_id", nil, r)
 			return
 		}
-		prev, err := s.Store.LastDecisionHash(ctx, tenant)
+		result, err := s.Store.InsertDecisionReceiptIdempotent(ctx, tenant, body.RequestID, decisionID, body.PolicyHash, body.Decision, canonicalBody, idempotencyBody, body.TraceID, body.SpanID, dedupeSince, receiptChainLockScope(s.Logger))
 		if err != nil {
 			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
-		hash := receipts.HashBytes(append([]byte(prev), compactBody...))
-		id, err := s.Store.InsertDecisionReceipt(ctx, tenant, decisionID, body.RequestID, body.PolicyHash, body.Decision, compactBody, prev, hash, body.TraceID, body.SpanID)
-		if err != nil {
-			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
+		if result.Outcome == receipts.IdempotencyReplayed {
+			w.WriteHeader(http.StatusOK)
+			writeJSON(w, receiptIngestResponse{ReceiptID: result.Record.ID.String(), Hash: result.Record.Hash, PrevHash: result.Record.PrevHash})
+			return
+		}
+		if result.Outcome == receipts.IdempotencyConflict {
+			writeErrorResponse(w, http.StatusConflict, protocol.ErrorCodeConflict, requestIDConflictMessage, requestIDConflictDetails(), r)
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
-		writeJSON(w, receiptIngestResponse{ReceiptID: id.String(), Hash: hash, PrevHash: prev})
+		writeJSON(w, receiptIngestResponse{ReceiptID: result.Record.ID.String(), Hash: result.Record.Hash, PrevHash: result.Record.PrevHash})
 	case "invocation":
 		var decisionID *uuid.UUID
 		if body.DecisionID != "" {
@@ -667,23 +679,26 @@ func (s *Server) handleReceiptsIngest(w http.ResponseWriter, r *http.Request) {
 			}
 			decisionID = &parsed
 		}
-		prev, err := s.Store.LastInvocationHash(ctx, tenant)
-		if err != nil {
-			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
-			return
-		}
-		hash := receipts.HashBytes(append([]byte(prev), compactBody...))
 		latencyMs := 0
 		if body.LatencyMs != nil {
 			latencyMs = *body.LatencyMs
 		}
-		id, err := s.Store.InsertInvocationReceipt(ctx, tenant, decisionID, body.RequestID, body.ToolName, body.Method, body.Path, body.Outcome, body.StatusCode, latencyMs, compactBody, prev, hash, body.TraceID, body.SpanID)
+		result, err := s.Store.InsertInvocationReceiptIdempotent(ctx, tenant, body.RequestID, decisionID, body.ToolName, body.Method, body.Path, body.Outcome, body.StatusCode, latencyMs, canonicalBody, idempotencyBody, body.TraceID, body.SpanID, dedupeSince, receiptChainLockScope(s.Logger))
 		if err != nil {
 			writeErrorResponse(w, http.StatusInternalServerError, protocol.ErrorCodeDBError, "db error", nil, r)
 			return
 		}
+		if result.Outcome == receipts.IdempotencyReplayed {
+			w.WriteHeader(http.StatusOK)
+			writeJSON(w, receiptIngestResponse{ReceiptID: result.Record.ID.String(), Hash: result.Record.Hash, PrevHash: result.Record.PrevHash})
+			return
+		}
+		if result.Outcome == receipts.IdempotencyConflict {
+			writeErrorResponse(w, http.StatusConflict, protocol.ErrorCodeConflict, requestIDConflictMessage, requestIDConflictDetails(), r)
+			return
+		}
 		w.WriteHeader(http.StatusCreated)
-		writeJSON(w, receiptIngestResponse{ReceiptID: id.String(), Hash: hash, PrevHash: prev})
+		writeJSON(w, receiptIngestResponse{ReceiptID: result.Record.ID.String(), Hash: result.Record.Hash, PrevHash: result.Record.PrevHash})
 	default:
 		writeErrorResponse(w, http.StatusBadRequest, "RECEIPT_INVALID", "invalid kind", nil, r)
 	}
@@ -756,6 +771,39 @@ func writeErrorResponse(w http.ResponseWriter, status int, code string, message 
 	protocol.WriteErrorResponse(w, status, code, message, reqID, "", traceID, errs)
 }
 
+func requestIDConflictDetails() []fieldError {
+	return []fieldError{{Field: "request_id", Message: "already used with different payload"}}
+}
+
+func receiptCanonicalizationError(err error) string {
+	switch {
+	case errors.Is(err, receipts.ErrCanonicalJSONNonASCII):
+		return "receipt body must be ASCII-only JSON"
+	case errors.Is(err, receipts.ErrCanonicalJSONFloat):
+		return "receipt body must not include floating point numbers"
+	case errors.Is(err, receipts.ErrCanonicalJSONTrailing):
+		return "receipt body must be a single JSON value"
+	default:
+		return "receipt body must be valid JSON"
+	}
+}
+
+func canonicalizeIdempotencyPayload(body receiptIngestRequest, canonicalBody []byte) ([]byte, error) {
+	payload := receipts.IdempotencyPayload{
+		Kind:       body.Kind,
+		RequestID:  body.RequestID,
+		DecisionID: body.DecisionID,
+		Decision:   body.Decision,
+		PolicyHash: body.PolicyHash,
+		ToolName:   body.ToolName,
+		Method:     body.Method,
+		Path:       body.Path,
+		Outcome:    body.Outcome,
+		Body:       json.RawMessage(canonicalBody),
+	}
+	return receipts.CanonicalizeIdempotencyPayload(payload)
+}
+
 func writeMethodNotAllowed(w http.ResponseWriter, r *http.Request) {
 	writeErrorResponse(w, http.StatusMethodNotAllowed, protocol.ErrorCodeMethodNotAllowed, "method not allowed", nil, r)
 }
@@ -790,6 +838,39 @@ func ensureRequestID(r *http.Request) string {
 	r.Header.Set("x-umbra-request-id", reqID)
 	r.Header.Set("x-request-id", reqID)
 	return reqID
+}
+
+var dedupeWindowOnce sync.Once
+var dedupeWindow time.Duration
+var chainScopeOnce sync.Once
+var chainScope string
+
+func requestIDDedupeWindow(logger *slog.Logger) time.Duration {
+	dedupeWindowOnce.Do(func() {
+		window, err := receipts.ResolveRequestIDDedupeWindow(os.Getenv("UMBRA_REQUEST_ID_DEDUPE_WINDOW"))
+		if err != nil {
+			logger.Warn("invalid UMBRA_REQUEST_ID_DEDUPE_WINDOW; using default", "err", err)
+		}
+		dedupeWindow = window
+	})
+	if dedupeWindow == 0 {
+		return receipts.DefaultRequestIDDedupeWindow
+	}
+	return dedupeWindow
+}
+
+func receiptChainLockScope(logger *slog.Logger) string {
+	chainScopeOnce.Do(func() {
+		scope, err := receipts.ResolveChainLockScope(os.Getenv("UMBRA_RECEIPT_CHAIN_LOCK_SCOPE"))
+		if err != nil {
+			logger.Warn("invalid UMBRA_RECEIPT_CHAIN_LOCK_SCOPE; using default", "err", err)
+		}
+		chainScope = scope
+	})
+	if chainScope == "" {
+		return "tenant"
+	}
+	return chainScope
 }
 
 func (s *Server) handleReceiptsExport(w http.ResponseWriter, r *http.Request) {

--- a/identity/control-plane/services/controlplane-api/internal/storage/storage.go
+++ b/identity/control-plane/services/controlplane-api/internal/storage/storage.go
@@ -1,9 +1,12 @@
 package storage
 
 import (
+	"bytes"
 	"context"
+	"database/sql"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"time"
@@ -239,6 +242,218 @@ func (s *Store) LastInvocationHash(ctx context.Context, tenant uuid.UUID) (strin
 	return *h, nil
 }
 
+type ReceiptIdempotencyRecord struct {
+	ID            uuid.UUID
+	Hash          string
+	PrevHash      string
+	BodyCanonical []byte
+	Payload       receipts.IdempotencyPayload
+}
+
+func (s *Store) FindDecisionReceiptByRequestID(ctx context.Context, tenant uuid.UUID, requestID string, since time.Time) (ReceiptIdempotencyRecord, bool, error) {
+	var rec ReceiptIdempotencyRecord
+	var prev *string
+	err := s.db.QueryRow(ctx, `
+    SELECT id, hash, prev_hash, body_canonical, decision_id, policy_hash, decision, request_id
+    FROM receipts_decision
+    WHERE tenant_id=$1 AND request_id=$2 AND ts >= $3
+    ORDER BY ts DESC
+    LIMIT 1`, tenant, requestID, since).Scan(&rec.ID, &rec.Hash, &prev, &rec.BodyCanonical, &rec.Payload.DecisionID, &rec.Payload.PolicyHash, &rec.Payload.Decision, &rec.Payload.RequestID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return rec, false, nil
+		}
+		return rec, false, err
+	}
+	if prev != nil {
+		rec.PrevHash = *prev
+	}
+	rec.Payload.Kind = "decision"
+	rec.Payload.Body = json.RawMessage(rec.BodyCanonical)
+	return rec, true, nil
+}
+
+func (s *Store) FindInvocationReceiptByRequestID(ctx context.Context, tenant uuid.UUID, requestID string, since time.Time) (ReceiptIdempotencyRecord, bool, error) {
+	var rec ReceiptIdempotencyRecord
+	var prev *string
+	var decisionID sql.NullString
+	err := s.db.QueryRow(ctx, `
+    SELECT id, hash, prev_hash, body_canonical, decision_id, tool_name, method, path, outcome, request_id
+    FROM receipts_invocation
+    WHERE tenant_id=$1 AND request_id=$2 AND ts >= $3
+    ORDER BY ts DESC
+    LIMIT 1`, tenant, requestID, since).Scan(&rec.ID, &rec.Hash, &prev, &rec.BodyCanonical, &decisionID, &rec.Payload.ToolName, &rec.Payload.Method, &rec.Payload.Path, &rec.Payload.Outcome, &rec.Payload.RequestID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return rec, false, nil
+		}
+		return rec, false, err
+	}
+	if prev != nil {
+		rec.PrevHash = *prev
+	}
+	rec.Payload.Kind = "invocation"
+	if decisionID.Valid {
+		rec.Payload.DecisionID = decisionID.String
+	}
+	rec.Payload.Body = json.RawMessage(rec.BodyCanonical)
+	return rec, true, nil
+}
+
+type IdempotentInsertResult struct {
+	Outcome receipts.IdempotencyOutcome
+	Record  ReceiptIdempotencyRecord
+}
+
+func (s *Store) InsertDecisionReceiptIdempotent(
+	ctx context.Context,
+	tenant uuid.UUID,
+	requestID string,
+	decisionID uuid.UUID,
+	policyHash string,
+	decision string,
+	body json.RawMessage,
+	idemBody json.RawMessage,
+	traceID string,
+	spanID string,
+	since time.Time,
+	chainScope string,
+) (IdempotentInsertResult, error) {
+	return s.insertReceiptIdempotent(ctx, tenant, "decision", requestID, since, idemBody, chainScope, func(tx pgx.Tx) (ReceiptIdempotencyRecord, error) {
+		prev, err := lastDecisionHashTx(ctx, tx, tenant)
+		if err != nil {
+			return ReceiptIdempotencyRecord{}, err
+		}
+		hash := receipts.HashBytes(append([]byte(prev), body...))
+		var id uuid.UUID
+		err = tx.QueryRow(ctx, `
+    INSERT INTO receipts_decision(tenant_id, decision_id, request_id, policy_hash, decision, body_json, body_canonical, prev_hash, hash, trace_id, span_id)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+    RETURNING id`,
+			tenant, decisionID, nullIfEmpty(requestID), policyHash, decision, body, body, nullIfEmpty(prev), hash, nullIfEmpty(traceID), nullIfEmpty(spanID),
+		).Scan(&id)
+		if err != nil {
+			return ReceiptIdempotencyRecord{}, err
+		}
+		return ReceiptIdempotencyRecord{ID: id, Hash: hash, PrevHash: prev, BodyCanonical: body}, nil
+	})
+}
+
+func (s *Store) InsertInvocationReceiptIdempotent(
+	ctx context.Context,
+	tenant uuid.UUID,
+	requestID string,
+	decisionID *uuid.UUID,
+	toolName string,
+	method string,
+	path string,
+	outcome string,
+	statusCode *int,
+	latencyMs int,
+	body json.RawMessage,
+	idemBody json.RawMessage,
+	traceID string,
+	spanID string,
+	since time.Time,
+	chainScope string,
+) (IdempotentInsertResult, error) {
+	return s.insertReceiptIdempotent(ctx, tenant, "invocation", requestID, since, idemBody, chainScope, func(tx pgx.Tx) (ReceiptIdempotencyRecord, error) {
+		prev, err := lastInvocationHashTx(ctx, tx, tenant)
+		if err != nil {
+			return ReceiptIdempotencyRecord{}, err
+		}
+		hash := receipts.HashBytes(append([]byte(prev), body...))
+		var id uuid.UUID
+		err = tx.QueryRow(ctx, `
+    INSERT INTO receipts_invocation(tenant_id, decision_id, request_id, tool_name, method, path, outcome, status_code, latency_ms, body_json, body_canonical, prev_hash, hash, trace_id, span_id)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+    RETURNING id`,
+			tenant,
+			decisionID,
+			nullIfEmpty(requestID),
+			toolName,
+			method,
+			path,
+			outcome,
+			statusCode,
+			latencyMs,
+			body,
+			body,
+			nullIfEmpty(prev),
+			hash,
+			nullIfEmpty(traceID),
+			nullIfEmpty(spanID),
+		).Scan(&id)
+		if err != nil {
+			return ReceiptIdempotencyRecord{}, err
+		}
+		return ReceiptIdempotencyRecord{ID: id, Hash: hash, PrevHash: prev, BodyCanonical: body}, nil
+	})
+}
+
+func (s *Store) insertReceiptIdempotent(
+	ctx context.Context,
+	tenant uuid.UUID,
+	kind string,
+	requestID string,
+	since time.Time,
+	idemBody json.RawMessage,
+	chainScope string,
+	insert func(pgx.Tx) (ReceiptIdempotencyRecord, error),
+) (IdempotentInsertResult, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return IdempotentInsertResult{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if strings.TrimSpace(requestID) != "" {
+		lockKey1, lockKey2 := receipts.AdvisoryLockPair(tenant.String(), kind, requestID)
+		if err := stor.AdvisoryLockTx(ctx, tx, lockKey1, lockKey2); err != nil {
+			return IdempotentInsertResult{}, err
+		}
+
+		var existing ReceiptIdempotencyRecord
+		var ok bool
+		switch kind {
+		case "decision":
+			existing, ok, err = findDecisionReceiptByRequestIDTx(ctx, tx, tenant, requestID, since)
+		case "invocation":
+			existing, ok, err = findInvocationReceiptByRequestIDTx(ctx, tx, tenant, requestID, since)
+		}
+		if err != nil {
+			return IdempotentInsertResult{}, err
+		}
+		if ok {
+			existingBytes, err := receipts.CanonicalizeIdempotencyPayload(existing.Payload)
+			if err != nil {
+				return IdempotentInsertResult{}, err
+			}
+			if len(existingBytes) == 0 || !bytes.Equal(existingBytes, idemBody) {
+				return IdempotentInsertResult{Outcome: receipts.IdempotencyConflict}, nil
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return IdempotentInsertResult{}, err
+			}
+			return IdempotentInsertResult{Outcome: receipts.IdempotencyReplayed, Record: existing}, nil
+		}
+	}
+
+	lockKey1, lockKey2 := receipts.ChainLockPair(tenant.String(), kind, time.Now().UTC(), chainScope)
+	if err := stor.AdvisoryLockTx(ctx, tx, lockKey1, lockKey2); err != nil {
+		return IdempotentInsertResult{}, err
+	}
+
+	record, err := insert(tx)
+	if err != nil {
+		return IdempotentInsertResult{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return IdempotentInsertResult{}, err
+	}
+	return IdempotentInsertResult{Outcome: receipts.IdempotencyInserted, Record: record}, nil
+}
+
 func (s *Store) InsertDecisionReceipt(ctx context.Context,
 	tenant uuid.UUID,
 	decisionID uuid.UUID,
@@ -306,6 +521,92 @@ func nullIfEmpty(s string) interface{} {
 		return nil
 	}
 	return s
+}
+
+func lastDecisionHashTx(ctx context.Context, tx pgx.Tx, tenant uuid.UUID) (string, error) {
+	var h *string
+	if err := tx.QueryRow(ctx, `
+    SELECT hash FROM receipts_decision
+    WHERE tenant_id=$1
+    ORDER BY ts DESC
+    LIMIT 1`, tenant).Scan(&h); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	if h == nil {
+		return "", nil
+	}
+	return *h, nil
+}
+
+func lastInvocationHashTx(ctx context.Context, tx pgx.Tx, tenant uuid.UUID) (string, error) {
+	var h *string
+	if err := tx.QueryRow(ctx, `
+    SELECT hash FROM receipts_invocation
+    WHERE tenant_id=$1
+    ORDER BY ts DESC
+    LIMIT 1`, tenant).Scan(&h); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	if h == nil {
+		return "", nil
+	}
+	return *h, nil
+}
+
+func findDecisionReceiptByRequestIDTx(ctx context.Context, tx pgx.Tx, tenant uuid.UUID, requestID string, since time.Time) (ReceiptIdempotencyRecord, bool, error) {
+	var rec ReceiptIdempotencyRecord
+	var prev *string
+	err := tx.QueryRow(ctx, `
+    SELECT id, hash, prev_hash, body_canonical, decision_id, policy_hash, decision, request_id
+    FROM receipts_decision
+    WHERE tenant_id=$1 AND request_id=$2 AND ts >= $3
+    ORDER BY ts DESC
+    LIMIT 1`, tenant, requestID, since).Scan(&rec.ID, &rec.Hash, &prev, &rec.BodyCanonical, &rec.Payload.DecisionID, &rec.Payload.PolicyHash, &rec.Payload.Decision, &rec.Payload.RequestID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return rec, false, nil
+		}
+		return rec, false, err
+	}
+	if prev != nil {
+		rec.PrevHash = *prev
+	}
+	rec.Payload.Kind = "decision"
+	rec.Payload.Body = json.RawMessage(rec.BodyCanonical)
+	return rec, true, nil
+}
+
+func findInvocationReceiptByRequestIDTx(ctx context.Context, tx pgx.Tx, tenant uuid.UUID, requestID string, since time.Time) (ReceiptIdempotencyRecord, bool, error) {
+	var rec ReceiptIdempotencyRecord
+	var prev *string
+	var decisionID sql.NullString
+	err := tx.QueryRow(ctx, `
+    SELECT id, hash, prev_hash, body_canonical, decision_id, tool_name, method, path, outcome, request_id
+    FROM receipts_invocation
+    WHERE tenant_id=$1 AND request_id=$2 AND ts >= $3
+    ORDER BY ts DESC
+    LIMIT 1`, tenant, requestID, since).Scan(&rec.ID, &rec.Hash, &prev, &rec.BodyCanonical, &decisionID, &rec.Payload.ToolName, &rec.Payload.Method, &rec.Payload.Path, &rec.Payload.Outcome, &rec.Payload.RequestID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return rec, false, nil
+		}
+		return rec, false, err
+	}
+	if prev != nil {
+		rec.PrevHash = *prev
+	}
+	rec.Payload.Kind = "invocation"
+	if decisionID.Valid {
+		rec.Payload.DecisionID = decisionID.String
+	}
+	rec.Payload.Body = json.RawMessage(rec.BodyCanonical)
+	return rec, true, nil
 }
 
 func (s *Store) ListReceiptChain(ctx context.Context, tenant uuid.UUID, limit int, kind string) ([]receipts.ChainRecord, error) {

--- a/identity/control-plane/services/mcp-adapter/internal/http-api/v0.go
+++ b/identity/control-plane/services/mcp-adapter/internal/http-api/v0.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -84,7 +85,7 @@ func (c *PDPClient) Decide(ctx context.Context, payload protocol.DecisionRequest
 
 type invocationStore interface {
 	LastInvocationHash(ctx context.Context, tenant uuid.UUID) (string, error)
-	InsertInvocationReceipt(ctx context.Context, tenant uuid.UUID, decisionID *uuid.UUID, requestID string, toolName string, method string, path string, outcome string, statusCode *int, latencyMs int, body json.RawMessage, prevHash string, hash string, traceID string, spanID string) error
+	InsertInvocationReceiptIdempotent(ctx context.Context, tenant uuid.UUID, requestID string, decisionID *uuid.UUID, toolName string, method string, path string, outcome string, statusCode *int, latencyMs int, body json.RawMessage, traceID string, spanID string, since time.Time, chainScope string) (receipts.IdempotencyOutcome, error)
 }
 
 type rpcRequest struct {
@@ -607,15 +608,17 @@ func writeInvocationReceipt(ctx context.Context, logger *slog.Logger, store invo
 		return
 	}
 
-	prev, err := store.LastInvocationHash(ctx, tenant)
+		since := receipts.RequestIDDedupeSince(time.Now().UTC(), requestIDDedupeWindow(logger))
+		outcomeResult, err := store.InsertInvocationReceiptIdempotent(ctx, tenant, requestID, decisionID, toolIdentifier(mcpCtx.Server, mcpCtx.Tool), mcpCtx.Method, mcpCtx.Tool, outcome, statusCode, totalLatency, bodyBytes, traceID, spanID, since, receiptChainLockScope(logger))
 	if err != nil {
-		logger.Error("receipt prev hash lookup failed", "err", err)
+		logger.Error("receipt insert failed", "err", err)
 		return
 	}
-
-	hash := receipts.HashBytes(append([]byte(prev), bodyBytes...))
-	if err := store.InsertInvocationReceipt(ctx, tenant, decisionID, requestID, toolIdentifier(mcpCtx.Server, mcpCtx.Tool), mcpCtx.Method, mcpCtx.Tool, outcome, statusCode, totalLatency, bodyBytes, prev, hash, traceID, spanID); err != nil {
-		logger.Error("receipt insert failed", "err", err)
+	switch outcomeResult {
+	case receipts.IdempotencyReplayed:
+		logger.Info("receipt idempotency replay", "request_id", requestID)
+	case receipts.IdempotencyConflict:
+		logger.Error("receipt idempotency conflict", "request_id", requestID)
 	}
 }
 
@@ -632,6 +635,40 @@ func toolIdentifier(serverName, toolName string) string {
 	}
 	return serverName + ":" + toolName
 }
+
+var dedupeWindowOnce sync.Once
+var dedupeWindow time.Duration
+var chainScopeOnce sync.Once
+var chainScope string
+
+func requestIDDedupeWindow(logger *slog.Logger) time.Duration {
+	dedupeWindowOnce.Do(func() {
+		window, err := receipts.ResolveRequestIDDedupeWindow(getenv("UMBRA_REQUEST_ID_DEDUPE_WINDOW", ""))
+		if err != nil {
+			logger.Warn("invalid UMBRA_REQUEST_ID_DEDUPE_WINDOW; using default", "err", err)
+		}
+		dedupeWindow = window
+	})
+	if dedupeWindow == 0 {
+		return receipts.DefaultRequestIDDedupeWindow
+	}
+	return dedupeWindow
+}
+
+func receiptChainLockScope(logger *slog.Logger) string {
+	chainScopeOnce.Do(func() {
+		scope, err := receipts.ResolveChainLockScope(getenv("UMBRA_RECEIPT_CHAIN_LOCK_SCOPE", ""))
+		if err != nil {
+			logger.Warn("invalid UMBRA_RECEIPT_CHAIN_LOCK_SCOPE; using default", "err", err)
+		}
+		chainScope = scope
+	})
+	if chainScope == "" {
+		return "tenant"
+	}
+	return chainScope
+}
+
 
 func writeRPCError(w http.ResponseWriter, status int, id json.RawMessage, message, code, requestID string, decisionID ...string) {
 	if strings.TrimSpace(requestID) == "" {

--- a/identity/control-plane/services/mcp-adapter/internal/http-api/v0_test.go
+++ b/identity/control-plane/services/mcp-adapter/internal/http-api/v0_test.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/umbra-labs/agent-identity-control-plane/packages/go/protocol"
+	"github.com/umbra-labs/agent-identity-control-plane/packages/go/receipts"
 )
 
 type captureStore struct {
@@ -40,7 +41,7 @@ func (s *captureStore) LastInvocationHash(_ context.Context, _ uuid.UUID) (strin
 	return "", nil
 }
 
-func (s *captureStore) InsertInvocationReceipt(_ context.Context, _ uuid.UUID, decisionID *uuid.UUID, requestID string, _ string, _ string, _ string, outcome string, _ *int, _ int, body json.RawMessage, _ string, _ string, traceID string, spanID string) error {
+func (s *captureStore) InsertInvocationReceiptIdempotent(_ context.Context, _ uuid.UUID, requestID string, decisionID *uuid.UUID, _ string, _ string, _ string, outcome string, _ *int, _ int, body json.RawMessage, traceID string, spanID string, _ time.Time, _ string) (receipts.IdempotencyOutcome, error) {
 	var parsed invocationReceiptBody
 	_ = json.Unmarshal(body, &parsed)
 	s.last = receiptCapture{
@@ -54,7 +55,7 @@ func (s *captureStore) InsertInvocationReceipt(_ context.Context, _ uuid.UUID, d
 		body:        parsed,
 		rawBody:     body,
 	}
-	return nil
+	return receipts.IdempotencyInserted, nil
 }
 
 func newTestHandler(t *testing.T, pepMode string, pdpTransport http.RoundTripper, toolTransport http.RoundTripper, store invocationStore) *mcpHandler {

--- a/identity/control-plane/services/mcp-adapter/internal/storage/storage.go
+++ b/identity/control-plane/services/mcp-adapter/internal/storage/storage.go
@@ -1,13 +1,19 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"strings"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	stor "github.com/umbra-labs/agent-identity-control-plane/packages/go/storage"
+	"github.com/umbra-labs/agent-identity-control-plane/packages/go/receipts"
 )
 
 type Store struct{ db *pgxpool.Pool }
@@ -28,6 +34,105 @@ func (s *Store) LastInvocationHash(ctx context.Context, tenant uuid.UUID) (strin
 		return "", nil
 	}
 	return *h, nil
+}
+
+func (s *Store) FindInvocationReceiptByRequestID(ctx context.Context, tenant uuid.UUID, requestID string, since time.Time) ([]byte, bool, error) {
+	var body []byte
+	err := s.db.QueryRow(ctx, `
+    SELECT body_canonical
+    FROM receipts_invocation
+    WHERE tenant_id=$1 AND request_id=$2 AND ts >= $3
+    ORDER BY ts DESC
+    LIMIT 1`, tenant, requestID, since).Scan(&body)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return body, true, nil
+}
+
+func (s *Store) InsertInvocationReceiptIdempotent(
+	ctx context.Context,
+	tenant uuid.UUID,
+	requestID string,
+	decisionID *uuid.UUID,
+	toolName string,
+	method string,
+	path string,
+	outcome string,
+	statusCode *int,
+	latencyMs int,
+	body json.RawMessage,
+	traceID string,
+	spanID string,
+	since time.Time,
+	chainScope string,
+) (receipts.IdempotencyOutcome, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if strings.TrimSpace(requestID) != "" {
+		lockKey1, lockKey2 := receipts.AdvisoryLockPair(tenant.String(), "invocation", requestID)
+		if err := stor.AdvisoryLockTx(ctx, tx, lockKey1, lockKey2); err != nil {
+			return receipts.IdempotencyConflict, err
+		}
+		existing, ok, err := findInvocationReceiptByRequestIDTx(ctx, tx, tenant, requestID, since)
+		if err != nil {
+			return receipts.IdempotencyConflict, err
+		}
+		if ok {
+			if len(existing) == 0 || !bytes.Equal(existing, body) {
+				return receipts.IdempotencyConflict, nil
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return receipts.IdempotencyConflict, err
+			}
+			return receipts.IdempotencyReplayed, nil
+		}
+	}
+
+	lockKey1, lockKey2 := receipts.ChainLockPair(tenant.String(), "invocation", time.Now().UTC(), chainScope)
+	if err := stor.AdvisoryLockTx(ctx, tx, lockKey1, lockKey2); err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+
+	prevHash, err := lastInvocationHashTx(ctx, tx, tenant)
+	if err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+	hash := receipts.HashBytes(append([]byte(prevHash), body...))
+
+	_, err = tx.Exec(ctx, `
+    INSERT INTO receipts_invocation(tenant_id, decision_id, request_id, tool_name, method, path, outcome, status_code, latency_ms, body_json, body_canonical, prev_hash, hash, trace_id, span_id)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+		tenant,
+		decisionID,
+		nullIfEmpty(requestID),
+		toolName,
+		method,
+		path,
+		outcome,
+		statusCode,
+		latencyMs,
+		body,
+		body,
+		nullIfEmpty(prevHash),
+		hash,
+		nullIfEmpty(traceID),
+		nullIfEmpty(spanID),
+	)
+	if err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+	return receipts.IdempotencyInserted, nil
 }
 
 func (s *Store) InsertInvocationReceipt(ctx context.Context,
@@ -73,4 +178,40 @@ func nullIfEmpty(s string) interface{} {
 		return nil
 	}
 	return s
+}
+
+func findInvocationReceiptByRequestIDTx(ctx context.Context, tx pgx.Tx, tenant uuid.UUID, requestID string, since time.Time) ([]byte, bool, error) {
+	var body []byte
+	err := tx.QueryRow(ctx, `
+    SELECT body_canonical
+    FROM receipts_invocation
+    WHERE tenant_id=$1 AND request_id=$2 AND ts >= $3
+    ORDER BY ts DESC
+    LIMIT 1`, tenant, requestID, since).Scan(&body)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return body, true, nil
+}
+
+func lastInvocationHashTx(ctx context.Context, tx pgx.Tx, tenant uuid.UUID) (string, error) {
+	var h *string
+	err := tx.QueryRow(ctx, `
+    SELECT hash FROM receipts_invocation
+    WHERE tenant_id=$1
+    ORDER BY ts DESC
+    LIMIT 1`, tenant).Scan(&h)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	if h == nil {
+		return "", nil
+	}
+	return *h, nil
 }

--- a/identity/control-plane/services/pdp/internal/http-api/v0.go
+++ b/identity/control-plane/services/pdp/internal/http-api/v0.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -212,10 +213,17 @@ func writeDecisionReceipt(ctx context.Context, logger *slog.Logger, store *dbsto
 		logger.Error("receipt canonical json failed", "err", err)
 		return
 	}
-	prev, _ := store.LastDecisionHash(ctx, tenant)
-	hash := receipts.HashBytes(append([]byte(prev), bodyBytes...))
-	if err := store.InsertDecisionReceipt(ctx, tenant, decisionID, requestID, policyHash, decision, bodyBytes, prev, hash, traceID, spanID); err != nil {
+	since := receipts.RequestIDDedupeSince(time.Now().UTC(), requestIDDedupeWindow(logger))
+	outcome, err := store.InsertDecisionReceiptIdempotent(ctx, tenant, requestID, decisionID, policyHash, decision, bodyBytes, traceID, spanID, since, receiptChainLockScope(logger))
+	if err != nil {
 		logger.Error("insert decision receipt failed", "err", err)
+		return
+	}
+	switch outcome {
+	case receipts.IdempotencyReplayed:
+		logger.Info("receipt idempotency replay", "request_id", requestID)
+	case receipts.IdempotencyConflict:
+		logger.Error("receipt idempotency conflict", "request_id", requestID)
 	}
 }
 
@@ -233,4 +241,37 @@ func writeError(w http.ResponseWriter, status int, code, message, requestID, tra
 
 func writeMethodNotAllowed(w http.ResponseWriter) {
 	writeError(w, http.StatusMethodNotAllowed, protocol.ErrorCodeMethodNotAllowed, "method not allowed", "", "")
+}
+
+var dedupeWindowOnce sync.Once
+var dedupeWindow time.Duration
+var chainScopeOnce sync.Once
+var chainScope string
+
+func requestIDDedupeWindow(logger *slog.Logger) time.Duration {
+	dedupeWindowOnce.Do(func() {
+		window, err := receipts.ResolveRequestIDDedupeWindow(os.Getenv("UMBRA_REQUEST_ID_DEDUPE_WINDOW"))
+		if err != nil {
+			logger.Warn("invalid UMBRA_REQUEST_ID_DEDUPE_WINDOW; using default", "err", err)
+		}
+		dedupeWindow = window
+	})
+	if dedupeWindow == 0 {
+		return receipts.DefaultRequestIDDedupeWindow
+	}
+	return dedupeWindow
+}
+
+func receiptChainLockScope(logger *slog.Logger) string {
+	chainScopeOnce.Do(func() {
+		scope, err := receipts.ResolveChainLockScope(os.Getenv("UMBRA_RECEIPT_CHAIN_LOCK_SCOPE"))
+		if err != nil {
+			logger.Warn("invalid UMBRA_RECEIPT_CHAIN_LOCK_SCOPE; using default", "err", err)
+		}
+		chainScope = scope
+	})
+	if chainScope == "" {
+		return "tenant"
+	}
+	return chainScope
 }

--- a/identity/control-plane/services/pdp/internal/storage/storage.go
+++ b/identity/control-plane/services/pdp/internal/storage/storage.go
@@ -1,14 +1,19 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	stor "github.com/umbra-labs/agent-identity-control-plane/packages/go/storage"
+	"github.com/umbra-labs/agent-identity-control-plane/packages/go/receipts"
 )
 
 type Store struct{ db *pgxpool.Pool }
@@ -52,6 +57,86 @@ func (s *Store) LastDecisionHash(ctx context.Context, tenant uuid.UUID) (string,
 	return *h, nil
 }
 
+func (s *Store) FindDecisionReceiptByRequestID(ctx context.Context, tenant uuid.UUID, requestID string, since time.Time) ([]byte, bool, error) {
+	var body []byte
+	err := s.db.QueryRow(ctx, `
+    SELECT body_canonical
+    FROM receipts_decision
+    WHERE tenant_id=$1 AND request_id=$2 AND ts >= $3
+    ORDER BY ts DESC
+    LIMIT 1`, tenant, requestID, since).Scan(&body)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return body, true, nil
+}
+
+func (s *Store) InsertDecisionReceiptIdempotent(
+	ctx context.Context,
+	tenant uuid.UUID,
+	requestID string,
+	decisionID uuid.UUID,
+	policyHash string,
+	decision string,
+	body json.RawMessage,
+	traceID string,
+	spanID string,
+	since time.Time,
+	chainScope string,
+) (receipts.IdempotencyOutcome, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if strings.TrimSpace(requestID) != "" {
+		lockKey1, lockKey2 := receipts.AdvisoryLockPair(tenant.String(), "decision", requestID)
+		if err := stor.AdvisoryLockTx(ctx, tx, lockKey1, lockKey2); err != nil {
+			return receipts.IdempotencyConflict, err
+		}
+		existing, ok, err := s.findDecisionReceiptByRequestIDTx(ctx, tx, tenant, requestID, since)
+		if err != nil {
+			return receipts.IdempotencyConflict, err
+		}
+		if ok {
+			if len(existing) == 0 || !bytes.Equal(existing, body) {
+				return receipts.IdempotencyConflict, nil
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return receipts.IdempotencyConflict, err
+			}
+			return receipts.IdempotencyReplayed, nil
+		}
+	}
+
+	lockKey1, lockKey2 := receipts.ChainLockPair(tenant.String(), "decision", time.Now().UTC(), chainScope)
+	if err := stor.AdvisoryLockTx(ctx, tx, lockKey1, lockKey2); err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+
+	prevHash, err := lastDecisionHashTx(ctx, tx, tenant)
+	if err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+	hash := receipts.HashBytes(append([]byte(prevHash), body...))
+
+	_, err = tx.Exec(ctx, `
+    INSERT INTO receipts_decision(tenant_id, decision_id, request_id, policy_hash, decision, body_json, body_canonical, prev_hash, hash, trace_id, span_id)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+		tenant, decisionID, nullIfEmpty(requestID), policyHash, decision, body, body, nullIfEmpty(prevHash), hash, nullIfEmpty(traceID), nullIfEmpty(spanID))
+	if err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+	return receipts.IdempotencyInserted, nil
+}
+
 func (s *Store) InsertDecisionReceipt(ctx context.Context,
 	tenant uuid.UUID,
 	decisionID uuid.UUID,
@@ -76,6 +161,42 @@ func nullIfEmpty(s string) interface{} {
 		return nil
 	}
 	return s
+}
+
+func (s *Store) findDecisionReceiptByRequestIDTx(ctx context.Context, tx pgx.Tx, tenant uuid.UUID, requestID string, since time.Time) ([]byte, bool, error) {
+	var body []byte
+	err := tx.QueryRow(ctx, `
+    SELECT body_canonical
+    FROM receipts_decision
+    WHERE tenant_id=$1 AND request_id=$2 AND ts >= $3
+    ORDER BY ts DESC
+    LIMIT 1`, tenant, requestID, since).Scan(&body)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return body, true, nil
+}
+
+func lastDecisionHashTx(ctx context.Context, tx pgx.Tx, tenant uuid.UUID) (string, error) {
+	var h *string
+	err := tx.QueryRow(ctx, `
+    SELECT hash FROM receipts_decision
+    WHERE tenant_id=$1
+    ORDER BY ts DESC
+    LIMIT 1`, tenant).Scan(&h)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	if h == nil {
+		return "", nil
+	}
+	return *h, nil
 }
 
 var _ = time.Now

--- a/identity/control-plane/services/pep-gateway/internal/http-api/v0.go
+++ b/identity/control-plane/services/pep-gateway/internal/http-api/v0.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -36,7 +37,7 @@ const maxPDPResponseBytes = 1 << 20
 
 type invocationStore interface {
 	LastInvocationHash(ctx context.Context, tenant uuid.UUID) (string, error)
-	InsertInvocationReceipt(ctx context.Context, tenant uuid.UUID, decisionID *uuid.UUID, requestID string, toolName string, method string, path string, outcome string, statusCode *int, latencyMs int, body json.RawMessage, prevHash string, hash string, traceID string, spanID string) error
+	InsertInvocationReceiptIdempotent(ctx context.Context, tenant uuid.UUID, requestID string, decisionID *uuid.UUID, toolName string, method string, path string, outcome string, statusCode *int, latencyMs int, body json.RawMessage, traceID string, spanID string, since time.Time, chainScope string) (receipts.IdempotencyOutcome, error)
 }
 
 type httpError struct {
@@ -398,21 +399,23 @@ func writeInvocationReceipt(ctx context.Context, logger *slog.Logger, store invo
 		return
 	}
 
-	prev, err := store.LastInvocationHash(ctx, tenant)
-	if err != nil {
-		logger.Error("receipt prev hash lookup failed", "err", err)
-		return
-	}
-
-	hash := receipts.HashBytes(append([]byte(prev), bodyBytes...))
 	sc := trace.SpanContextFromContext(ctx)
 	traceID, spanID := "", ""
 	if sc.IsValid() {
 		traceID, spanID = sc.TraceID().String(), sc.SpanID().String()
 	}
 
-	if err := store.InsertInvocationReceipt(ctx, tenant, decisionID, requestID, toolName, method, path, outcome, statusCode, latencyMs, bodyBytes, prev, hash, traceID, spanID); err != nil {
+		since := receipts.RequestIDDedupeSince(time.Now().UTC(), requestIDDedupeWindow(logger))
+		outcomeResult, err := store.InsertInvocationReceiptIdempotent(ctx, tenant, requestID, decisionID, toolName, method, path, outcome, statusCode, latencyMs, bodyBytes, traceID, spanID, since, receiptChainLockScope(logger))
+	if err != nil {
 		logger.Error("receipt insert failed", "err", err)
+		return
+	}
+	switch outcomeResult {
+	case receipts.IdempotencyReplayed:
+		logger.Info("receipt idempotency replay", "request_id", requestID)
+	case receipts.IdempotencyConflict:
+		logger.Error("receipt idempotency conflict", "request_id", requestID)
 	}
 }
 
@@ -434,6 +437,40 @@ func proxyURLHost(_ *httputil.ReverseProxy) string {
 }
 
 func intPtr(v int) *int { return &v }
+
+var dedupeWindowOnce sync.Once
+var dedupeWindow time.Duration
+var chainScopeOnce sync.Once
+var chainScope string
+
+func requestIDDedupeWindow(logger *slog.Logger) time.Duration {
+	dedupeWindowOnce.Do(func() {
+		window, err := receipts.ResolveRequestIDDedupeWindow(getenv("UMBRA_REQUEST_ID_DEDUPE_WINDOW", ""))
+		if err != nil {
+			logger.Warn("invalid UMBRA_REQUEST_ID_DEDUPE_WINDOW; using default", "err", err)
+		}
+		dedupeWindow = window
+	})
+	if dedupeWindow == 0 {
+		return receipts.DefaultRequestIDDedupeWindow
+	}
+	return dedupeWindow
+}
+
+func receiptChainLockScope(logger *slog.Logger) string {
+	chainScopeOnce.Do(func() {
+		scope, err := receipts.ResolveChainLockScope(getenv("UMBRA_RECEIPT_CHAIN_LOCK_SCOPE", ""))
+		if err != nil {
+			logger.Warn("invalid UMBRA_RECEIPT_CHAIN_LOCK_SCOPE; using default", "err", err)
+		}
+		chainScope = scope
+	})
+	if chainScope == "" {
+		return "tenant"
+	}
+	return chainScope
+}
+
 
 func classifyPDPError(err error, status int) (string, string) {
 	if err == nil {

--- a/identity/control-plane/services/pep-gateway/internal/http-api/v0_test.go
+++ b/identity/control-plane/services/pep-gateway/internal/http-api/v0_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -18,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/umbra-labs/agent-identity-control-plane/packages/go/protocol"
+	"github.com/umbra-labs/agent-identity-control-plane/packages/go/receipts"
 )
 
 // TestObserveVsEnforceMode tests that PEP_MODE correctly controls behavior for DENY decisions
@@ -129,7 +131,7 @@ func (s *captureStore) LastInvocationHash(_ context.Context, _ uuid.UUID) (strin
 	return "", nil
 }
 
-func (s *captureStore) InsertInvocationReceipt(_ context.Context, _ uuid.UUID, decisionID *uuid.UUID, requestID string, _ string, _ string, _ string, _ string, _ *int, _ int, body json.RawMessage, _ string, _ string, traceID string, spanID string) error {
+func (s *captureStore) InsertInvocationReceiptIdempotent(_ context.Context, _ uuid.UUID, requestID string, decisionID *uuid.UUID, _ string, _ string, _ string, _ string, _ *int, _ int, body json.RawMessage, traceID string, spanID string, _ time.Time, _ string) (receipts.IdempotencyOutcome, error) {
 	s.captured = capturedInvocation{
 		requestID:  requestID,
 		decisionID: decisionID,
@@ -137,7 +139,7 @@ func (s *captureStore) InsertInvocationReceipt(_ context.Context, _ uuid.UUID, d
 		spanID:     spanID,
 		body:       append(json.RawMessage(nil), body...),
 	}
-	return nil
+	return receipts.IdempotencyInserted, nil
 }
 
 func TestInvocationCorrelationIDs(t *testing.T) {

--- a/identity/control-plane/services/pep-gateway/internal/storage/storage.go
+++ b/identity/control-plane/services/pep-gateway/internal/storage/storage.go
@@ -1,15 +1,19 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	stor "github.com/umbra-labs/agent-identity-control-plane/packages/go/storage"
+	"github.com/umbra-labs/agent-identity-control-plane/packages/go/receipts"
 )
 
 type Store struct{ db *pgxpool.Pool }
@@ -33,6 +37,105 @@ func (s *Store) LastInvocationHash(ctx context.Context, tenant uuid.UUID) (strin
 		return "", nil
 	}
 	return *h, nil
+}
+
+func (s *Store) FindInvocationReceiptByRequestID(ctx context.Context, tenant uuid.UUID, requestID string, since time.Time) ([]byte, bool, error) {
+	var body []byte
+	err := s.db.QueryRow(ctx, `
+    SELECT body_canonical
+    FROM receipts_invocation
+    WHERE tenant_id=$1 AND request_id=$2 AND ts >= $3
+    ORDER BY ts DESC
+    LIMIT 1`, tenant, requestID, since).Scan(&body)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return body, true, nil
+}
+
+func (s *Store) InsertInvocationReceiptIdempotent(
+	ctx context.Context,
+	tenant uuid.UUID,
+	requestID string,
+	decisionID *uuid.UUID,
+	toolName string,
+	method string,
+	path string,
+	outcome string,
+	statusCode *int,
+	latencyMs int,
+	body json.RawMessage,
+	traceID string,
+	spanID string,
+	since time.Time,
+	chainScope string,
+) (receipts.IdempotencyOutcome, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if strings.TrimSpace(requestID) != "" {
+		lockKey1, lockKey2 := receipts.AdvisoryLockPair(tenant.String(), "invocation", requestID)
+		if err := stor.AdvisoryLockTx(ctx, tx, lockKey1, lockKey2); err != nil {
+			return receipts.IdempotencyConflict, err
+		}
+		existing, ok, err := findInvocationReceiptByRequestIDTx(ctx, tx, tenant, requestID, since)
+		if err != nil {
+			return receipts.IdempotencyConflict, err
+		}
+		if ok {
+			if len(existing) == 0 || !bytes.Equal(existing, body) {
+				return receipts.IdempotencyConflict, nil
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return receipts.IdempotencyConflict, err
+			}
+			return receipts.IdempotencyReplayed, nil
+		}
+	}
+
+	lockKey1, lockKey2 := receipts.ChainLockPair(tenant.String(), "invocation", time.Now().UTC(), chainScope)
+	if err := stor.AdvisoryLockTx(ctx, tx, lockKey1, lockKey2); err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+
+	prevHash, err := lastInvocationHashTx(ctx, tx, tenant)
+	if err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+	hash := receipts.HashBytes(append([]byte(prevHash), body...))
+
+	_, err = tx.Exec(ctx, `
+    INSERT INTO receipts_invocation(tenant_id, decision_id, request_id, tool_name, method, path, outcome, status_code, latency_ms, body_json, body_canonical, prev_hash, hash, trace_id, span_id)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+		tenant,
+		decisionID,
+		nullIfEmpty(requestID),
+		toolName,
+		method,
+		path,
+		outcome,
+		statusCode,
+		latencyMs,
+		body,
+		body,
+		nullIfEmpty(prevHash),
+		hash,
+		nullIfEmpty(traceID),
+		nullIfEmpty(spanID),
+	)
+	if err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return receipts.IdempotencyConflict, err
+	}
+	return receipts.IdempotencyInserted, nil
 }
 
 func (s *Store) InsertInvocationReceipt(ctx context.Context,
@@ -78,4 +181,40 @@ func nullIfEmpty(s string) interface{} {
 		return nil
 	}
 	return s
+}
+
+func findInvocationReceiptByRequestIDTx(ctx context.Context, tx pgx.Tx, tenant uuid.UUID, requestID string, since time.Time) ([]byte, bool, error) {
+	var body []byte
+	err := tx.QueryRow(ctx, `
+    SELECT body_canonical
+    FROM receipts_invocation
+    WHERE tenant_id=$1 AND request_id=$2 AND ts >= $3
+    ORDER BY ts DESC
+    LIMIT 1`, tenant, requestID, since).Scan(&body)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return body, true, nil
+}
+
+func lastInvocationHashTx(ctx context.Context, tx pgx.Tx, tenant uuid.UUID) (string, error) {
+	var h *string
+	err := tx.QueryRow(ctx, `
+    SELECT hash FROM receipts_invocation
+    WHERE tenant_id=$1
+    ORDER BY ts DESC
+    LIMIT 1`, tenant).Scan(&h)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	if h == nil {
+		return "", nil
+	}
+	return *h, nil
 }

--- a/identity/control-plane/ui/contracts/openapi.ts
+++ b/identity/control-plane/ui/contracts/openapi.ts
@@ -253,6 +253,7 @@ export interface components {
     ReceiptIngestBase: {
       /** @enum {string} */
       kind: "decision" | "invocation";
+      /** @description Idempotency key for receipt ingest (tenant-scoped). */
       request_id: string;
       decision_id?: string;
       trace_id?: string;
@@ -636,6 +637,12 @@ export interface operations {
       };
     };
     responses: {
+      /** @description Idempotent replay (existing receipt) */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ReceiptIngestResponse"];
+        };
+      };
       /** @description Created */
       201: {
         content: {
@@ -644,6 +651,15 @@ export interface operations {
       };
       /** @description Invalid request */
       400: {
+        headers: {
+          "x-umbra-request-id": components["headers"]["RequestId"];
+        };
+        content: {
+          "application/json": components["schemas"]["ErrorResponse"];
+        };
+      };
+      /** @description Request ID conflict */
+      409: {
         headers: {
           "x-umbra-request-id": components["headers"]["RequestId"];
         };


### PR DESCRIPTION
Idempotency + replay protection: 

 - Implementation: included request_id dedupe with advisory locks and optional chain scoping across controlplane‑api, PDP, PEP, and MCP.

- Canonicalization: added deterministic raw JSON handling (sorted keys, ASCII‑only, no floats) with typed errors and clearer ingest messages.
- Tests: expanded integration coverage for replay/conflict, canonicalized payloads, concurrent duplicates, and invalid bodies.
- Contracts + Docs: updated OpenAPI responses (200/409) and schema notes, plus idempotency/canonicalization/dev docs and doc index; regenerated TS contracts to keep schemas aligned.

Completed tickets (links)

- UMBRA-0028 Idempotency + Replay Protection Semantics: #40